### PR TITLE
update shells repo for Leap15.2.x86_64 profile from Leap15.1 stand-in. Fixes #1 

### DIFF
--- a/rockstor.kiwi
+++ b/rockstor.kiwi
@@ -263,10 +263,9 @@ which includes aarch64 relevant content -->
                 profiles="Leap15.1.x86_64">
         <source path="http://download.opensuse.org/repositories/shells/openSUSE_Leap_15.1/"/>
     </repository>
-    <!-- TODO: NOT YET AVAILABLE FOR LEAP15.2 so use 15.1 source for now -->
     <repository type="rpm-md" alias="shells" priority="105" imageinclude="true"
                 profiles="Leap15.2.x86_64">
-        <source path="http://download.opensuse.org/repositories/shells/openSUSE_Leap_15.1/"/>
+        <source path="http://download.opensuse.org/repositories/shells/openSUSE_Leap_15.2/"/>
     </repository>
     <!-- TODO: NOT YET AVAILABLE FOR LEAP15.2 aarch64 so use Factory_ARM source for now -->
     <repository type="rpm-md" alias="shells" priority="105" imageinclude="true"


### PR DESCRIPTION
The shells repo is now available for Leap15.2 in x86_64 arch. Previously the Leap15.1 variant was our 'stand in' and was tested as working but best if use the appropriate target if available. Thanks to @FroggyFlox for the issue prompt.

Addresses prior TODO: removed as part of this commit.

Fixes #1 

Tested as working as per the following comments.