### PR TITLE
kiwi-ng command example refers to different profile than announced #5

### DIFF
--- a/README.md
+++ b/README.md
@@ -110,7 +110,7 @@ Any assistance with this endeavour would be much appreciated. See: kiwi-ng's new
 ### Leap15.2.x86_64 profile
 Executed, as the root user, in the directory containing this repositories rockstor.kiwi file.
 ```shell script
-kiwi-ng --profile=Leap15.1.x86_64 --type oem system build --description ./ --target-dir /home/kiwi-images/
+kiwi-ng --profile=Leap15.2.x86_64 --type oem system build --description ./ --target-dir /home/kiwi-images/
 ```
 
 ### Leap15.2.RaspberryPi4 profile


### PR DESCRIPTION
The example command for Leap 15.2 actually uses the Leap 15.1 profile. Fix by editing profile in example command for this section. Leap 15.2 is our target distro platform and so for those cutting and pasting we are best having this correct.

Thanks to @FroggyFlox in the following issue for reporting this example command error.

Fixes #5

