### PR TITLE
Pin Rockstor package version. Fixes #10

### DIFF
--- a/rockstor.kiwi
+++ b/rockstor.kiwi
@@ -397,7 +397,7 @@ which includes aarch64 relevant content -->
         <package name="ypbind"/>
         <!--ROCKSTOR PACKAGE-->
         <!--Change to reflect the version specified, i.e. 4.0.0-0 -->
-        <package name="rockstor"/>
+        <package name="rockstor-4.0.0-0"/>
     </packages>
     <packages type="image" profiles="Leap15.2.RaspberryPi4">
         <package name="raspberrypi-firmware" arch="aarch64"/>


### PR DESCRIPTION
By pinning our testing repository sourced rockstor rpm package version we ensure default installer builds contain known working rpm versions. In this case to a release candidate for the stable channel.

Fixes #10 
Please see issue text for more context.

Ready for review.