### PR TITLE
Tidy up of initial login message. Fixes #14

### DIFF
--- a/root/etc/issue
+++ b/root/etc/issue
@@ -1,7 +1,8 @@
 Welcome to Rockstor built on openSUSE - Kernel \r (\l).
 
 Your Web-UI should be available directly after:
-"[  OK  ] Started Rockstor bootstrapping tasks." appears below.
+"[  OK  ] Started Rockstor bootstrapping tasks."
+appears below.
 
 First login here as the 'root' user for further instructions.
 


### PR DESCRIPTION
Help to highlight the quoted systemd output on the initial command line login by placing it on a line of it's own.

Fixes #14 

