### PR TITLE
Improve pre-edit default for image 'name'. Fixes #16

### DIFF
--- a/rockstor.kiwi
+++ b/rockstor.kiwi
@@ -12,7 +12,7 @@ which includes aarch64 relevant content -->
 <!-- OBS-Profiles: @BUILD_FLAVOR@ -->
 
 <!-- Change to "Rockstor-<baseos-machine>" e.g. "Rockstor-Leap15.2-RaspberryPi4" -->
-<image schemaversion="7.1" name="Rockstor-">
+<image schemaversion="7.1" name="Rockstor-NAS">
 
     <description type="system">
         <author>Philip Guyton</author>


### PR DESCRIPTION
Set default image name to be "Rockstor-NAS" to avoid prior observed, 'no edit' builds resulting in inelegant Grub boot text and raw image progress reporting header text.

Fixes #16
