### PR TITLE
auto import all configured repo GPG keys bar rockstor's. Fixes #15

### DIFF
--- a/config.sh
+++ b/config.sh
@@ -35,6 +35,7 @@ suseImportBuildKey
 
 #======================================
 # Import Rockstor GPG Key
+# https://raw.githubusercontent.com/rockstor/rockstor-core/master/conf/ROCKSTOR-GPG-KEY
 # N.B. Expires 2025-05-29
 #--------------------------------------
 t=$(mktemp)
@@ -63,65 +64,9 @@ rpm --import $t
 rm -f $t
 
 #======================================
-# Import repo GPG Key for
-# obs://build.opensuse.org/network
-# N.B. Expires 2020-03-30
+# Auto import all repo GPG keys
 #--------------------------------------
-t=$(mktemp)
-cat - <<EOF > $t
------BEGIN PGP PUBLIC KEY BLOCK-----
-Version: GnuPG v1.4.5 (GNU/Linux)
-
-mQENBFJBt/wBCADAht3d/ilNuyzaXYw/QwTRvmjyoDvfXw+H/3Fvk1zlDZoiKPPc
-a1wCVBINUZl7vYM2OXqbJwYa++JP2Q48xKSvC6thbRc/YLievkbcvTemf7IaREfl
-CTjoYpoqXHa9kHMw1aALDm8CNU88jZmnV7v9L6hKkbYDxie+jpoj7D6B9JlxgNJ4
-5dQyRNsFGVcIl4Vplt1HyGc5Q5nQI/VgS2rlF/IOXmhRQBc4LEDdU8R2IKnkU4ee
-S7TWanAigGAQhxGuCkS39/CWzc1DhLhjlNhBl/+RTPejkqJtAy00ZLps3+RqUN1Y
-CU/Fsr7aRlYVGqQ/BlptwV0XQ2VVYJX2oEBBABEBAAG0MG5ldHdvcmsgT0JTIFBy
-b2plY3QgPG5ldHdvcmtAYnVpbGQub3BlbnN1c2Uub3JnPokBPAQTAQIAJgUCWmMc
-aQIbAwUJDEAUbQYLCQgHAwIEFQIIAwQWAgMBAh4BAheAAAoJEGLrGgkXKA3fjsoI
-ALSXmXzFCpTxg8a6tvXkqddY/qAmeBMNUf7hslI9wN3leNmCrnuHS8TbHWYJZgtw
-8M5fKL3aRQYaIiqqm1XOUF0OqwYNDj5V3y38mM68NYOkzgSP7foMwZp9Y0TlGhtI
-L8weA+2RUjB4hwwGMAYMqkRZyKW3NhPqdlGGoXac1ilwEyGXFHdOLbkhtyS+P2yb
-/EvaKIN5cMLzRZKeYgdp9WuAirV+yV/SDbgvabW098lrWhGLltlRRDQgMV883p8I
-ERMI1wlLFZGnHL3mfBWGeQ24M/DaBOdXQDtfBLCJ9nGztmDBUb8i6GFWU7nD2TGi
-8mYUsED1ZDwO/0jdvJ4gSluIRgQTEQIABgUCUkG3/AAKCRA7MBG3a51lIzhdAJ9v
-d6XPffMZRcCGgDEY5OaTn/MsCQCgrXbeZpFJgnirSrc8rRonvzYFiF4=
-=Gvly
------END PGP PUBLIC KEY BLOCK-----
-EOF
-rpm --import $t
-rm -f $t
-
-#======================================
-# Import repo GPG Key for
-# https://build.opensuse.org/project/show/shells
-# N.B. Expires Unknown
-#--------------------------------------
-t=$(mktemp)
-cat - <<EOF > $t
------BEGIN PGP PUBLIC KEY BLOCK-----
-Version: GnuPG v1.4.5 (GNU/Linux)
-
-mQGiBEeWW10RBADvumfiqUVFRTo4UAGZcjsJ4mMNiMT84Oe34iDodBdy8lk7cdpe
-DFRV0zLv9PFph0CyRysEh9fNKXyxW76x+o3zQLikoUXOycSqVszrsKfYOvedFAro
-bbGZoWL7CZCrSmKAscxJESr9F8bem0KvDn07tn4N6+B8EDrapoNjw0RhJwCgmd5S
-LRdbYbwvBboDY2AEg6zidp8D+gMY99cB92C9+93mx1+69aHf2wGwHIY9je7w9dgc
-XIRqSoDZ7KufC+NuKMVh4ny6TqrgUikPrgt6Ccp2hYh7BlHjNScVPm6+e4HYtdTA
-4uA8sPd6CTOMFqvJEvnNTsFqzdRhcQkecyODIgXO6eDT/eSyw6ZAsdBBxvoXq062
-Lu5hBADJmqHo8CeqyfAd/sjTBrH4aNEn2j4NzSUg/14OjGSvLGaJk4H2elBuJ/0o
-mfoMamRXwTNOysIbrcVBFc+B3rfRxbmQCtUvcDquCfOOGG5yW8Jz9eTMW+wbI1I3
-wjdq2Bny4jeY+EkHEJvoaJBwjNJOLIgSzU2zqlfRm54VUmc+m7Quc2hlbGxzIE9C
-UyBQcm9qZWN0IDxzaGVsbHNAYnVpbGQub3BlbnN1c2Uub3JnPohmBBMRAgAmBQJb
-5mIWAhsDBQkYbra5BgsJCAcDAgQVAggDBBYCAwECHgECF4AACgkQhc/kUbkeHouX
-KACZAS5MyfY0p8h9T2auwS9DmUBd7kEAn3S5tZ7vPMPdSPj0pTwJDhz5zMKJiEYE
-ExECAAYFAkeWW10ACgkQOzARt2udZSMmKQCfSH+QgNSEDkhRcE/ALKh7jqA7zAsA
-mgPnEw8AkhckGx4SM5o8gH6cDBq/
-=ngPn
------END PGP PUBLIC KEY BLOCK-----
-EOF
-rpm --import $t
-rm -f $t
+zypper --non-interactive --gpg-auto-import-keys refresh
 
 #======================================
 # Deactivate services


### PR DESCRIPTION
Previously network:time & shells repo GPG keys were imported 'by-hand'. Replace with auto import of all configured repos for the given profile.

Fixes #15

Currently all repos bar the rockstor testing one are OBS, and so we can auto import the required GPG keys once the initial root tree is in place via config.sh. This ensure all current gpg keys are pre-installed at image build time, avoiding the maintenance overhead of updating gpg keys as they expire.

Currently the rockstor testing repo does not present this capability but that could be addressed/added in the future.

Also adds raw GitHub url reference for canonical Rockstor GPG key.

Details of repository status re GPG key import in the resulting image/install will be reported in the comments.