### PR TITLE
Switch to official boxes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,47 @@
+*.py[cod]
+
+# C extensions
+*.so
+
+# Packages
+*.egg
+*.egg-info
+dist
+build
+eggs
+parts
+bin
+var
+sdist
+develop-eggs
+.installed.cfg
+#lib
+lib64
+
+# Installer logs
+pip-log.txt
+
+# Unit test / coverage reports
+.coverage
+.tox
+nosetests.xml
+
+# Translations
+*.mo
+
+# Mr Developer
+.mr.developer.cfg
+.project
+.pydevproject
+
+# Pycharm
+.idea/
+
+# Node Modules
+node_modules/
+
+# VS Code
+.vscode
+
+# Vagrant
+#.vagrant

--- a/.gitignore
+++ b/.gitignore
@@ -44,4 +44,4 @@ node_modules/
 .vscode
 
 # Vagrant
-#.vagrant
+.vagrant

--- a/vagrant_env/README.md
+++ b/vagrant_env/README.md
@@ -9,9 +9,17 @@ It is assumped that you have the follow software packages install on you host ma
 - Vagrant (https://www.vagrantup.com/downloads)
 - VirtualBox (https://www.virtualbox.org/wiki/Downloads)
 
-Both packages are available on Linux, Mac OSX and Windows.
+The above packages are available on Linux, Mac OSX and Windows.
 
-It is also assumed that you have a local copy of this repository [rockstor-installer](https://github.com/rockstor/rockstor-installer) on your machine, see the top level README.md, and are currently within the 'vagrant_env' directory: where the Vagrantfile, build.sh, and run_kiwi.sh are.
+You will also need one of the following virtualisation platforms:
+  - <b>Linux users:</b> may prefer to use libvirt, qemu + kxm (see https://github.com/vagrant-libvirt/vagrant-libvirt)
+
+    or 
+  - Virtualbox is available on all platforms (https://www.virtualbox.org/wiki/Downloads)
+
+It is also assumed that you have a local copy of this repository [rockstor-installer](https://github.com/rockstor/rockstor-installer) 
+on your machine, see the top level README.md, and are currently within the 'vagrant_env' directory: where the 
+Vagrantfile, build.sh, and run_kiwi.sh are located.
 
 Configuring Profiles
 --------------------
@@ -29,22 +37,18 @@ comment/uncomment the 'PROFILE' variable to the desired value:
 Vagrant Boxes for OpenSUSE Leap
 -------------------------------
 
-This vagrant file uses the vagrant box: [bento/opensuse-leap-15](https://app.vagrantup.com/bento/boxes/opensuse-leap-15) 
+This vagrant file uses the vagrant boxes: 
+- [opensuse/leap-15.2.x86_64](https://app.vagrantup.com/opensuse/boxes/Leap-15.2.x86_64)
 
+or
+- [opensuse/leap-15.2.aarch64](https://app.vagrantup.com/opensuse/boxes/Leap-15.2.aarch64)
+
+eg.
 ```
-v.vm.box = bento/opensuse-leap-15 
+v.vm.box = 'opensuse/Leap-15.2.x86_64' 
 ```
 
-Explanantion:
-
-*Bento*: is a provider of many base boxes for vagrant, based on official images with the virtualisation tools added.  
-
-*opensuse-leap-15*: is a 'tag' for 'Leap 15 latest' and will track the latest release of leap 15. Should you require 
-a fixed version of leap there are specific tags available. eg. 
-
-```
-v.vm.box = bento/opensuse-leap-15.2 
-```
+These boxes for vagrant are based on official images with the virtualisation tools added.  
 
 Building the Rockstor ISO installer
 -----------------------------------
@@ -54,10 +58,18 @@ On Mac OSX, Linux and Windows with Bash installed, execute the build script:
 ./build.sh
 ```
 
+This will, by default, build and provision an OpenSUSE Leap 15.2 vagrant box in libvirt.
+
+Should you prefer to user virtual box you can perform the following:
+
+```shell script
+./build.sh virtualbox
+```
+
 On Windows without Bash installed, executed:
 
 ```
-vagrant up
+vagrant up --provider=virtualbox
 vagrant ssh -c "cd /home/vagrant; /vagrant/run_kiwi.sh"
 ```
 
@@ -71,30 +83,30 @@ Managing the Virtual Machine
 To manage the Vagrant box VM simple type the following from this directory...
 
 - Bring up a vagrant box VM
-```shell script
-vagrant up
-```
+    ```shell script
+    vagrant up --provider=libvirt
+    ```
+  or for virtual box
+    ```shell script
+    vagrant up --provider=virtualbox
+    ```
 
 - Reconfigure the vagrant box VM following a change to the Vagrantfile:
-
-```shell script
-vagrant reload
-```
+    ```shell script
+    vagrant reload
+    ```
 
 - If you change the provisioner section of the Vagrantfile, you can rerun just that part as follows:
-
-```shell script
-vagrant provision
-```
+    ```shell script
+    vagrant provision
+    ```
 
 - Destroy the vagrant box VM:
-
-```shell script
-vagrant destroy
-```
+    ```shell script
+    vagrant destroy
+    ```
 
 - If you wish to ssh into the vagrant box VM to poke around, try this:
-
-```shell script
-vagrant ssh
-```
+    ```shell script
+    vagrant ssh
+    ```

--- a/vagrant_env/Vagrantfile
+++ b/vagrant_env/Vagrantfile
@@ -5,14 +5,16 @@
 required_plugins = %w(
     vagrant-host-shell
     vagrant-sshfs
-    vagrant-vbguest
+    vagrant-libvirt
     )
 required_plugins.each do |plugin|
   system "vagrant plugin install #{plugin}" unless Vagrant.has_plugin? plugin
 end
+system "vagrant plugin uninstall vagrant-vbguest"
 
 MEM = 2048
 CPU = 2
+PROFILE = ENV['PROFILE'] || 'x86_64'
 
 VAGRANTFILE_API_VERSION = '2'
 #
@@ -22,35 +24,48 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
 
     config.vm.synced_folder "./", "/vagrant"
     config.vm.synced_folder "../", "/home/vagrant/rockstor-installer"
-    config.vm.network "private_network", type: "dhcp"
 
     config.vm.define "rockstor-installer" do |v|
         v.vm.hostname = "rockstor-installer"
-        v.vm.box = 'bento/opensuse-leap-15'
+        if PROFILE == "x86_64" then
+            v.vm.box = 'opensuse/Leap-15.2.x86_64'
+        else
+            v.vm.box = 'opensuse/Leap-15.2.aarch64'
+        end
 
         # Provider specific variable
+        v.vm.provider :libvirt do |lv|
+            lv.driver = "qemu"
+            lv.nested = true
+            lv.memory = MEM
+            lv.cpus = CPU
+        end
         v.vm.provider :virtualbox do |vb|
             vb.memory = MEM
             vb.cpus = CPU
         end
 
+        if PROFILE == "x86_64" then
+            config.vm.provision "shell", inline: <<-SHELL
+                sudo zypper --non-interactive addrepo --refresh http://download.opensuse.org/repositories/Virtualization:/Appliances:/Builder/openSUSE_Leap_15.2/ appliance-builder
+                sudo zypper --non-interactive --gpg-auto-import-keys refresh
+            SHELL
+        else
+            config.vm.provision "shell", inline: <<-SHELL
+                sudo zypper --non-interactive addrepo --refresh http://download.opensuse.org/repositories/Virtualization:/Appliances:/Builder/openSUSE_Leap_15.2_ARM/ appliance-builder
+                sudo zypper --non-interactive --gpg-auto-import-keys refresh
+            SHELL
+        end
+
         config.vm.provision "shell", inline: <<-SHELL
-            PROFILE=x86_64
-            #PROFILE=AArch64
             REPO_URL="https://github.com/rockstor/rockstor-installer.git"
             REPO_DIR="rockstor-installer/"
-            if [ "$PROFILE" = "x86_64" ]; then
-                sudo zypper --non-interactive addrepo --refresh http://download.opensuse.org/repositories/Virtualization:/Appliances:/Builder/openSUSE_Leap_15.2/ appliance-builder
-            else
-                sudo zypper --non-interactive addrepo --refresh http://download.opensuse.org/repositories/Virtualization:/Appliances:/Builder/openSUSE_Leap_15.2_ARM/ appliance-builder
-            fi
-            sudo zypper --non-interactive --gpg-auto-import-keys refresh
-            sudo zypper --non-interactive install git
+            sudo zypper --non-interactive install git btrfsprogs gfxboot
             sudo zypper --non-interactive install python3-kiwi
             if [ ! -e ${REPO_DIR} ]; then
                 git clone ${REPO_URL} ${REPO_DIR}
             fi
-            #/vagrant/run_kiwi.sh
         SHELL
     end
 end
+

--- a/vagrant_env/build.sh
+++ b/vagrant_env/build.sh
@@ -3,9 +3,12 @@ set -e
 set -u
 #set -x
 
+VAGRANT_PROVIDER=${1:-libvirt}
+PROFILE=${2:-x86_64}
+
 VAGRANT_HOST="rockstor-installer"
 
-vagrant up ${VAGRANT_HOST}
+vagrant up ${VAGRANT_HOST} --provider ${VAGRANT_PROVIDER}
 
 VAGRANT_PATH="/home/vagrant"
 #vagrant ssh -c "ls -l ${VAGRANT_PATH}" ${VAGRANT_HOST}
@@ -13,4 +16,4 @@ VAGRANT_PATH="/home/vagrant"
 CODE_PATH="${VAGRANT_PATH}"
 echo "$(basename ${BASH_SOURCE[0]}): CODE_PATH is '${CODE_PATH}'"
 
-vagrant ssh -c "cd ${CODE_PATH}; /vagrant/run_kiwi.sh" ${VAGRANT_HOST}
+vagrant ssh -c "cd ${CODE_PATH}; /vagrant/run_kiwi.sh ${PROFILE}" ${VAGRANT_HOST}

--- a/vagrant_env/run_kiwi.sh
+++ b/vagrant_env/run_kiwi.sh
@@ -3,9 +3,10 @@ set -e
 set -u
 #set -x
 
-KIWI_BUILD_DIR="/home/vagrant/kiwi-images/"
-PROFILE="x86_64"
+PROFILE=${1:-x86_64}
 #PROFILE="RaspberryPi4"
+
+KIWI_BUILD_DIR="/home/vagrant/kiwi-images/"
 REPO_DIR="rockstor-installer/"
 
 echo '============================================='
@@ -16,7 +17,20 @@ if [ -e ${KIWI_BUILD_DIR} ]; then
     sudo rm -rf "${KIWI_BUILD_DIR}/build";
 fi
 sudo kiwi-ng --profile=Leap15.2."${PROFILE}" --type oem system build --description ./ --target-dir "${KIWI_BUILD_DIR}/"
-sudo find ${KIWI_BUILD_DIR} -name "*.iso" -exec cp {} /vagrant/ \;
+
+# Fix the output file names to match RPM version.
+RPM_VERSION=$(cat "${KIWI_BUILD_DIR}/build/image-root.log" | sed -n 's/.*Installing: rockstor-\(.*\)\.[a-z0-9_]* .*/\1/p')
+source /etc/os-release
+BASE_OS=$(echo ${PRETTY_NAME} | cut -d ' ' -f2,3 | tr -d ' ')
+
+for file in $(find ${KIWI_BUILD_DIR} -maxdepth 1 -name "Rockstor-*"); do
+  new_file=$(echo "$file" | sed "s/\(Rockstor-\).${PROFILE}-4.0.0-0\(.*\)/\1${BASE_OS}-${PROFILE}-${RPM_VERSION}\2/")
+  if [ "$file" != "$new_file" ]; then
+    sudo mv -v "$file" "${new_file}"
+  fi
+done
+
+sudo find ${KIWI_BUILD_DIR} -name "*.iso" -exec cp -v {} /vagrant/ \;
 echo '============================================='
 echo 'Finished Build'
 echo '============================================='


### PR DESCRIPTION
As discussed in rockstor-core issue 2206 (rockstor/rockstor-core#2206) switching the environment to the newly available 'official' OpenSUSE vagrant boxes.

Also added and defaulted to libvirt, along side virtual box as a option.