### PR TITLE
Switch to official vagrant boxes.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,47 @@
+*.py[cod]
+
+# C extensions
+*.so
+
+# Packages
+*.egg
+*.egg-info
+dist
+build
+eggs
+parts
+bin
+var
+sdist
+develop-eggs
+.installed.cfg
+#lib
+lib64
+
+# Installer logs
+pip-log.txt
+
+# Unit test / coverage reports
+.coverage
+.tox
+nosetests.xml
+
+# Translations
+*.mo
+
+# Mr Developer
+.mr.developer.cfg
+.project
+.pydevproject
+
+# Pycharm
+.idea/
+
+# Node Modules
+node_modules/
+
+# VS Code
+.vscode
+
+# Vagrant
+.vagrant

--- a/vagrant_env/README.md
+++ b/vagrant_env/README.md
@@ -29,22 +29,18 @@ comment/uncomment the 'PROFILE' variable to the desired value:
 Vagrant Boxes for OpenSUSE Leap
 -------------------------------
 
-This vagrant file uses the vagrant box: [bento/opensuse-leap-15](https://app.vagrantup.com/bento/boxes/opensuse-leap-15) 
+This vagrant file uses the vagrant boxes: 
+- [opensuse/leap-15.2.x86_64](https://app.vagrantup.com/opensuse/boxes/Leap-15.2.x86_64)
 
+or
+- [opensuse/leap-15.2.aarch64](https://app.vagrantup.com/opensuse/boxes/Leap-15.2.aarch64)
+
+eg.
 ```
-v.vm.box = bento/opensuse-leap-15 
+v.vm.box = 'opensuse/Leap-15.2.x86_64' 
 ```
 
-Explanantion:
-
-*Bento*: is a provider of many base boxes for vagrant, based on official images with the virtualisation tools added.  
-
-*opensuse-leap-15*: is a 'tag' for 'Leap 15 latest' and will track the latest release of leap 15. Should you require 
-a fixed version of leap there are specific tags available. eg. 
-
-```
-v.vm.box = bento/opensuse-leap-15.2 
-```
+These boxes for vagrant are based on official images with the virtualisation tools added.  
 
 Building the Rockstor ISO installer
 -----------------------------------

--- a/vagrant_env/Vagrantfile
+++ b/vagrant_env/Vagrantfile
@@ -1,7 +1,7 @@
 # -*- mode: ruby -*-
 # vi: set ft=ruby :
 
-# Requires vagrant-host-shell and vagrant-vbguest
+# Required plugins
 required_plugins = %w(
     vagrant-host-shell
     vagrant-sshfs
@@ -9,6 +9,7 @@ required_plugins = %w(
 required_plugins.each do |plugin|
   system "vagrant plugin install #{plugin}" unless Vagrant.has_plugin? plugin
 end
+# Excluded plugins
 system "vagrant plugin uninstall vagrant-vbguest"
 
 MEM = 2048

--- a/vagrant_env/Vagrantfile
+++ b/vagrant_env/Vagrantfile
@@ -5,14 +5,15 @@
 required_plugins = %w(
     vagrant-host-shell
     vagrant-sshfs
-    vagrant-vbguest
     )
 required_plugins.each do |plugin|
   system "vagrant plugin install #{plugin}" unless Vagrant.has_plugin? plugin
 end
+system "vagrant plugin uninstall vagrant-vbguest"
 
 MEM = 2048
 CPU = 2
+PROFILE = ENV['PROFILE'] || 'x86_64'
 
 VAGRANTFILE_API_VERSION = '2'
 #
@@ -26,7 +27,11 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
 
     config.vm.define "rockstor-installer" do |v|
         v.vm.hostname = "rockstor-installer"
-        v.vm.box = 'bento/opensuse-leap-15'
+        if PROFILE == "x86_64" then
+            v.vm.box = 'opensuse/Leap-15.2.x86_64'
+        else
+            v.vm.box = 'opensuse/Leap-15.2.aarch64'
+        end
 
         # Provider specific variable
         v.vm.provider :virtualbox do |vb|
@@ -34,23 +39,27 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
             vb.cpus = CPU
         end
 
+        if PROFILE == "x86_64" then
         config.vm.provision "shell", inline: <<-SHELL
-            PROFILE=x86_64
-            #PROFILE=AArch64
+                sudo zypper --non-interactive addrepo --refresh http://download.opensuse.org/repositories/Virtualization:/Appliances:/Builder/openSUSE_Leap_15.2/ appliance-builder
+                sudo zypper --non-interactive --gpg-auto-import-keys refresh
+            SHELL
+            else
+            config.vm.provision "shell", inline: <<-SHELL
+                sudo zypper --non-interactive addrepo --refresh http://download.opensuse.org/repositories/Virtualization:/Appliances:/Builder/openSUSE_Leap_15.2_ARM/ appliance-builder
+            sudo zypper --non-interactive --gpg-auto-import-keys refresh
+            SHELL
+        end
+
+        config.vm.provision "shell", inline: <<-SHELL
             REPO_URL="https://github.com/rockstor/rockstor-installer.git"
             REPO_DIR="rockstor-installer/"
-            if [ "$PROFILE" = "x86_64" ]; then
-                sudo zypper --non-interactive addrepo --refresh http://download.opensuse.org/repositories/Virtualization:/Appliances:/Builder/openSUSE_Leap_15.2/ appliance-builder
-            else
-                sudo zypper --non-interactive addrepo --refresh http://download.opensuse.org/repositories/Virtualization:/Appliances:/Builder/openSUSE_Leap_15.2_ARM/ appliance-builder
-            fi
-            sudo zypper --non-interactive --gpg-auto-import-keys refresh
-            sudo zypper --non-interactive install git
+            sudo zypper --non-interactive install git btrfsprogs gfxboot
             sudo zypper --non-interactive install python3-kiwi
             if [ ! -e ${REPO_DIR} ]; then
                 git clone ${REPO_URL} ${REPO_DIR}
             fi
-            #/vagrant/run_kiwi.sh
         SHELL
     end
 end
+

--- a/vagrant_env/build.sh
+++ b/vagrant_env/build.sh
@@ -3,6 +3,7 @@ set -e
 set -u
 #set -x
 
+PROFILE=${1:-x86_64}
 VAGRANT_HOST="rockstor-installer"
 
 vagrant up ${VAGRANT_HOST}
@@ -13,4 +14,4 @@ VAGRANT_PATH="/home/vagrant"
 CODE_PATH="${VAGRANT_PATH}"
 echo "$(basename ${BASH_SOURCE[0]}): CODE_PATH is '${CODE_PATH}'"
 
-vagrant ssh -c "cd ${CODE_PATH}; /vagrant/run_kiwi.sh" ${VAGRANT_HOST}
+vagrant ssh -c "cd ${CODE_PATH}; /vagrant/run_kiwi.sh ${PROFILE}" ${VAGRANT_HOST}

--- a/vagrant_env/run_kiwi.sh
+++ b/vagrant_env/run_kiwi.sh
@@ -3,9 +3,10 @@ set -e
 set -u
 #set -x
 
-KIWI_BUILD_DIR="/home/vagrant/kiwi-images/"
-PROFILE="x86_64"
+PROFILE=${1:-x86_64}
 #PROFILE="RaspberryPi4"
+
+KIWI_BUILD_DIR="/home/vagrant/kiwi-images/"
 REPO_DIR="rockstor-installer/"
 
 echo '============================================='


### PR DESCRIPTION
As discussed in rockstor-core issue 2206 (rockstor/rockstor-core#2206) switching the environment to the newly available 'official' OpenSUSE vagrant boxes.

My test environments were:

**Mac OSX High Sierra:**

ansible 2.9.11
VirtualBox 6.1.12
Vagrant 2.2.9
Vagrant pugs:
 - vagrant-host-shell (0.0.4, global)
 - vagrant-libvirt (0.1.2, global)
 - vagrant-sshfs (1.3.5, global)

**Mac OSX Catalina:**

ansible 2.9.11
VirtualBox 6.1.10
Vagrant 2.2.9
 - vagrant-host-shell (0.0.4, global)
 - vagrant-libvirt (0.1.2, global)
 - vagrant-sshfs (1.3.5, global)
