### PR TITLE
add potentially missing dependencies of btrfsprogs and gfxboot. Fixes #26

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,7 +81,7 @@ For a Leap 15.2 host OS from kiwi-ng's doc [Installation](https://osinside.githu
 Any x86_64 machine, although keep in mind that building the ISO installer is computationally expensive so Haswell or better is recommended.
 ```shell script
 sudo zypper addrepo http://download.opensuse.org/repositories/Virtualization:/Appliances:/Builder/openSUSE_Leap_15.2/ appliance-builder
-sudo zypper install python3-kiwi
+sudo zypper install python3-kiwi btrfsprogs gfxboot
 ```
 
 #### AArch64 host (e.g. a Pi4) for AArch64 profiles
@@ -95,7 +95,7 @@ Pi4 EEPROM/bootloader version "Jun 15 2020" or later will be required for USB bo
    
 ```shell script
 sudo zypper addrepo https://download.opensuse.org/repositories/Virtualization:/Appliances:/Builder/openSUSE_Leap_15.2_ARM/ appliance-builder
-sudo zypper install python3-kiwi
+sudo zypper install python3-kiwi btrfsprogs gfxboot
 ```
 
 ### Edit rockstor.kiwi

--- a/README.md
+++ b/README.md
@@ -95,7 +95,7 @@ Pi4 EEPROM/bootloader version "Jun 15 2020" or later will be required for USB bo
    
 ```shell script
 sudo zypper addrepo https://download.opensuse.org/repositories/Virtualization:/Appliances:/Builder/openSUSE_Leap_15.2_ARM/ appliance-builder
-sudo zypper install python3-kiwi btrfsprogs gfxboot
+sudo zypper install python3-kiwi btrfsprogs
 ```
 
 ### Edit rockstor.kiwi


### PR DESCRIPTION
In some host instance of the suggested Leap 15.2, i.e. some vagrant boxes and in the Pi4 images for Leap15.2 there is not default install/use of btrfsprogs. Fix by adding to instructions as our target image construction relies absolutely on this packages. As well as the also found to be missing in some instances gfxboot.

Fixes #26 

