### PR TITLE
apply grub distributor config for custom menu text. Fixes #30

### DIFF
--- a/config.sh
+++ b/config.sh
@@ -179,6 +179,15 @@ EOF
 fi
 
 #======================================
+# Apply grub config
+# Setup Grub Distributor option
+#--------------------------------------
+echo >> /etc/default/grub
+echo "# Set distributor for custom menu text" >> /etc/default/grub
+echo 'GRUB_DISTRIBUTOR="Rockstor NAS"' >> /etc/default/grub
+echo >> /etc/default/grub
+
+#======================================
 # Umount kernel filesystems
 #--------------------------------------
 baseCleanMount


### PR DESCRIPTION
Adds "GRUB_DISTRIBUTOR" entry to /etc/default/grub to set user facing grub options to be as intended. As a standard Grub config element this should persist grub updates. No version text is intended to keep things simple.

Fixes #30

Tested to be working as intended, i.e. user facing text on resulting installs shows the intended:

> Rocsktor NAS
> Advanced options for Rockstor NAS

Also note that where as our default pre-custom-edit "name=" wiki config text is "Rockstor-NAS" the move here to "Rocsktor NAS" (space) is intended to help distinguish the origin of such text between DIY installer build name settings and what is as a result of this Grub config entry: "-" installer (compressed) grub options, " " installed (expanded) grub options.
