### PR TITLE
Remove addition of the network:time repo for chrony

### DIFF
--- a/rockstor.kiwi
+++ b/rockstor.kiwi
@@ -263,28 +263,6 @@ which includes aarch64 relevant content -->
                 profiles="Tumbleweed.x86_64">
         <source path="http://download.opensuse.org/update/tumbleweed/"/>
     </repository>
-    <!-- https://build.opensuse.org/project/show/network:time -->
-    <!-- Primarily to fix chronyc 100% cpu via NM dispatcher.d/20-chrony  -->
-    <!-- Provides much newer versions of chrony and ntp -->
-    <!-- Required for Leap15.1 -->
-    <repository type="rpm-md" alias="Leap_15_1_NetTime" imageinclude="true"
-                priority="97" profiles="Leap15.1.x86_64">
-        <source path="http://download.opensuse.org/repositories/network:/time/openSUSE_Leap_15.1/"/>
-    </repository>
-    <!-- Required for Leap15.2 beta. Thanks to Flox for reporting/testing -->
-    <!-- TODO: Check requirement for this in Leap15.2 release, remove if possible -->
-    <repository type="rpm-md" alias="Leap_15_2_NetTime" imageinclude="true"
-                priority="97" profiles="Leap15.2.x86_64">
-        <source path="http://download.opensuse.org/repositories/network:/time/openSUSE_Leap_15.2/"/>
-    </repository>
-    <!-- Excluding for now from Leap15.2.RaspberryPi4 as causes dependency issues i.e. -->
-    <!-- nothing provides libm.so.6(GLIBC_2.29)(64bit) needed by chrony-3.5-92.3.aarch64 -->
-    <!-- nothing provides libevent_core-2.1.so.7()(64bit) needed by ntp-4.2.8p15-3.2.aarch64 -->
-    <!-- It may be the 100% cpu bug on chrony is now sorted or does not affect aarch64 -->
-    <!--    <repository type="rpm-md" alias="Leap_15_2_NetTime" imageinclude="true"-->
-    <!--                priority="97" profiles="Leap15.2.RaspberryPi4">-->
-    <!--        <source path="https://download.opensuse.org/repositories/network:/time/openSUSE_Factory_ARM/"/>-->
-    <!--    </repository>-->
     <!-- https://osinside.github.io/kiwi/working_with_kiwi/xml_description.html#adding-repositories -->
     <!-- Local-Repository on build host: for pre-installed rockstor package -->
     <!--    <repository type="rpm-dir" alias="Local-Repository">-->


### PR DESCRIPTION
Fixes #36.  
@phillxnet, ready for review.

This pull request (PR) simply proposes to remove the addition of the `network:time` repository that was used to run a more up-to-date version of `chrony` in order to avoid a 100% CPU usage bug (see #36 for details).

## Summary of changes
This PR simply removes from `rockstor.kiwi` the lines pertaining to adding the `network:time` repository for all concerned profiles.

## Functional testing
The resulting ISO was installed on bare metal and confirmed to:
- install successfully
- the `network:time` repository is not installed anymore
```
rocktest:~ # zypper repos --uri
Repository priorities in effect:                                                                                                                                                                                                               (See 'zypper lr -P' for details)
      97 (raised priority)  :  1 repository
      99 (default priority) :  2 repositories
     105 (lowered priority) :  1 repository

# | Alias                              | Name                               | Enabled | GPG Check | Refresh | URI
--+------------------------------------+------------------------------------+---------+-----------+---------+-----------------------------------------------------------------------------------------------------
1 | Leap_15_2                          | Leap_15_2                          | Yes     | (r ) Yes  | Yes     | http://download.opensuse.org/distribution/leap/15.2/repo/oss/
2 | Leap_15_2_Updates                  | Leap_15_2_Updates                  | Yes     | (r ) Yes  | Yes     | http://download.opensuse.org/update/leap/15.2/oss/
3 | home_rockstor_branches_Base_System | home_rockstor_branches_Base_System | Yes     | (r ) Yes  | Yes     | http://download.opensuse.org/repositories/home:/rockstor:/branches:/Base:/System/openSUSE_Leap_15.2/
4 | shells                             | shells                             | Yes     | (r ) Yes  | Yes     | http://download.opensuse.org/repositories/shells/openSUSE_Leap_15.2/
```
- `chrony` is indeed installed from the Leap_15_2_Updates repository
```
rocktest:~ # zypper info chrony
Loading repository data...
Reading installed packages...

Information for package chrony:
-------------------------------
Repository     : Leap_15_2_Updates
Name           : chrony
Version        : 3.2-lp152.13.3.2
Arch           : x86_64
Vendor         : openSUSE
Installed Size : 442.4 KiB
Installed      : Yes
Status         : up-to-date
Source package : chrony-3.2-lp152.13.3.2.src
Summary        : System Clock Synchronization Client and Server
Description    : 
(...)
```
- `chrony` is running at boot
```
rocktest:~ # systemctl status chronyd
● chronyd.service - NTP client/server
   Loaded: loaded (/usr/lib/systemd/system/chronyd.service; enabled; vendor preset: enabled)
   Active: active (running) since Tue 2020-12-29 13:58:21 EST; 8min ago
     Docs: man:chronyd(8)
           man:chrony.conf(5)
 Main PID: 626 (chronyd)
    Tasks: 1
   CGroup: /system.slice/chronyd.service
           └─626 /usr/sbin/chronyd

Dec 29 13:58:20 localhost systemd[1]: Starting NTP client/server...
Dec 29 13:58:21 localhost chronyd[626]: chronyd version 3.2 starting (+CMDMON +NTP +REFCLOCK +RTC +PRIVDROP -SCFILTER +SECHASH -SIGND +ASYNCDNS +IPV6 -DEBUG)
Dec 29 13:58:21 localhost chronyd[626]: Could not open IPv6 command socket : Address family not supported by protocol
Dec 29 13:58:21 localhost chronyd[626]: Frequency 9.765 +/- 33.190 ppm read from /var/lib/chrony/drift
Dec 29 13:58:21 localhost systemd[1]: Started NTP client/server.
Dec 29 13:58:31 localhost.localdomain chronyd[626]: Selected source X.X.X.X
Dec 29 13:59:36 localhost.localdomain chronyd[626]: Selected source X.X.X.X
Dec 29 14:03:55 localhost.localdomain chronyd[626]: Selected source X.X.X.X
```
- no 100% CPU usage by `chrony` can be seen using `htop`.

The above was true after several reboots.

## Kiwi build log

<details><summary>Full kiwi build log</summary>

```
#sudo kiwi-ng --profile=Leap15.2.x86_64 --type oem system build --description ./ --target-dir /home/kiwi-images-dev/
[sudo] password for root: 
[ INFO    ]: 13:35:28 | Reading runtime config file: /etc/kiwi.yml
[ INFO    ]: 13:35:28 | Reading runtime config file: /etc/kiwi.yml
[ INFO    ]: 13:35:28 | Loading XML description
[ INFO    ]: 13:35:28 | Support for XML markup available
[ INFO    ]: 13:35:29 | --> loaded ./rockstor.kiwi
[ INFO    ]: 13:35:29 | --> Selected build type: oem
[ INFO    ]: 13:35:29 | --> Selected profiles: Leap15.2.x86_64
[ INFO    ]: 13:35:29 | Reading runtime config file: /etc/kiwi.yml
[ INFO    ]: 13:35:29 | Reading runtime config file: /etc/kiwi.yml
[ INFO    ]: 13:35:29 | Reading runtime config file: /etc/kiwi.yml
[ INFO    ]: 13:35:29 | Reading runtime config file: /etc/kiwi.yml
[ INFO    ]: 13:35:29 | Preparing new root system
[ INFO    ]: 13:35:29 | Setup root directory: /home/kiwi-images-dev/build/image-root
[ INFO    ]: 13:35:29 | Setting up repository obs://Virtualization:Appliances:Builder/openSUSE_Leap_15.2
[ INFO    ]: 13:35:29 | --> Type: rpm-md
[ INFO    ]: 13:35:29 | --> Priority: 1
[ INFO    ]: 13:35:29 | Reading runtime config file: /etc/kiwi.yml
[ INFO    ]: 13:35:30 | --> Translated: http://download.opensuse.org/repositories/Virtualization:/Appliances:/Builder/openSUSE_Leap_15.2/
[ INFO    ]: 13:35:30 | --> Alias: kiwi
[ INFO    ]: 13:35:30 | Reading runtime config file: /etc/kiwi.yml
[ INFO    ]: 13:35:30 | Setting up repository obs://openSUSE:Leap:15.2/standard
[ INFO    ]: 13:35:30 | --> Type: rpm-md
[ INFO    ]: 13:35:30 | Reading runtime config file: /etc/kiwi.yml
[ INFO    ]: 13:35:31 | --> Translated: http://download.opensuse.org/distribution/leap/15.2/repo/oss/
[ INFO    ]: 13:35:31 | --> Alias: Leap_15_2
[ INFO    ]: 13:35:31 | Reading runtime config file: /etc/kiwi.yml
[ INFO    ]: 13:35:31 | Setting up repository http://download.opensuse.org/update/leap/15.2/oss/
[ INFO    ]: 13:35:31 | --> Type: rpm-md
[ INFO    ]: 13:35:31 | Reading runtime config file: /etc/kiwi.yml
[ INFO    ]: 13:35:31 | --> Translated: http://download.opensuse.org/update/leap/15.2/oss/
[ INFO    ]: 13:35:31 | --> Alias: Leap_15_2_Updates
[ INFO    ]: 13:35:31 | Reading runtime config file: /etc/kiwi.yml
[ INFO    ]: 13:35:31 | Setting up repository http://updates.rockstor.com:8999/rockstor-testing/leap/15.2/
[ INFO    ]: 13:35:31 | --> Type: rpm-md
[ INFO    ]: 13:35:31 | Reading runtime config file: /etc/kiwi.yml
[ INFO    ]: 13:35:31 | --> Translated: http://updates.rockstor.com:8999/rockstor-testing/leap/15.2/
[ INFO    ]: 13:35:31 | --> Alias: Rockstor-Testing
[ INFO    ]: 13:35:31 | Reading runtime config file: /etc/kiwi.yml
[ INFO    ]: 13:35:31 | Setting up repository http://download.opensuse.org/repositories/shells/openSUSE_Leap_15.2/
[ INFO    ]: 13:35:31 | --> Type: rpm-md
[ INFO    ]: 13:35:31 | --> Priority: 105
[ INFO    ]: 13:35:31 | Reading runtime config file: /etc/kiwi.yml
[ INFO    ]: 13:35:31 | --> Translated: http://download.opensuse.org/repositories/shells/openSUSE_Leap_15.2/
[ INFO    ]: 13:35:31 | --> Alias: shells
[ INFO    ]: 13:35:31 | Reading runtime config file: /etc/kiwi.yml
[ INFO    ]: 13:35:31 | Setting up repository http://download.opensuse.org/repositories/home:/rockstor:/branches:/Base:/System/openSUSE_Leap_15.2/
[ INFO    ]: 13:35:31 | --> Type: rpm-md
[ INFO    ]: 13:35:31 | --> Priority: 97
[ INFO    ]: 13:35:31 | Reading runtime config file: /etc/kiwi.yml
[ INFO    ]: 13:35:31 | --> Translated: http://download.opensuse.org/repositories/home:/rockstor:/branches:/Base:/System/openSUSE_Leap_15.2/
[ INFO    ]: 13:35:31 | --> Alias: home_rockstor_branches_Base_System
[ INFO    ]: 13:35:31 | Reading runtime config file: /etc/kiwi.yml
[ INFO    ]: 13:35:31 | Using package manager backend: zypper
[ INFO    ]: 13:35:31 | Installing bootstrap packages
[ INFO    ]: 13:35:31 | --> collection type: onlyRequired
[ INFO    ]: 13:35:31 | --> package: ca-certificates
[ INFO    ]: 13:35:31 | --> package: ca-certificates-cacert
[ INFO    ]: 13:35:31 | --> package: ca-certificates-mozilla
[ INFO    ]: 13:35:31 | --> package: cracklib-dict-full
[ INFO    ]: 13:35:31 | --> package: filesystem
[ INFO    ]: 13:35:31 | --> package: glibc-locale
[ INFO    ]: 13:35:31 | --> package: openSUSE-release
[ INFO    ]: 13:35:31 | --> package: udev
[ INFO    ]: 13:35:31 | --> package: zypper
[ INFO    ]: Processing: [########################################] 100%
[ INFO    ]: 13:36:32 | Installing system (chroot) for build type: oem
[ INFO    ]: 13:36:32 | --> collection type: onlyRequired
[ INFO    ]: 13:36:32 | --> package: NetworkManager
[ INFO    ]: 13:36:32 | --> package: NetworkManager-branding-upstream
[ INFO    ]: 13:36:32 | --> package: adaptec-firmware
[ INFO    ]: 13:36:32 | --> package: at
[ INFO    ]: 13:36:32 | --> package: avahi
[ INFO    ]: 13:36:32 | --> package: bash-completion
[ INFO    ]: 13:36:32 | --> package: bind-utils
[ INFO    ]: 13:36:32 | --> package: btrfsmaintenance
[ INFO    ]: 13:36:32 | --> package: btrfsprogs
[ INFO    ]: 13:36:32 | --> package: checkmedia
[ INFO    ]: 13:36:32 | --> package: chrony
[ INFO    ]: 13:36:32 | --> package: cifs-utils
[ INFO    ]: 13:36:32 | --> package: cronie
[ INFO    ]: 13:36:32 | --> package: cryptsetup
[ INFO    ]: 13:36:32 | --> package: cyrus-sasl-plain
[ INFO    ]: 13:36:32 | --> package: dhcp-client
[ INFO    ]: 13:36:32 | --> package: dmraid
[ INFO    ]: 13:36:32 | --> package: dnf-plugins-core
[ INFO    ]: 13:36:32 | --> package: dnf-yum
[ INFO    ]: 13:36:32 | --> package: docker
[ INFO    ]: 13:36:32 | --> package: dosfstools
[ INFO    ]: 13:36:32 | --> package: dracut
[ INFO    ]: 13:36:32 | --> package: dracut-kiwi-oem-dump
[ INFO    ]: 13:36:32 | --> package: dracut-kiwi-oem-repart
[ INFO    ]: 13:36:32 | --> package: fbiterm
[ INFO    ]: 13:36:32 | --> package: firewalld
[ INFO    ]: 13:36:32 | --> package: fontconfig
[ INFO    ]: 13:36:32 | --> package: fonts-config
[ INFO    ]: 13:36:32 | --> package: gfxboot-branding-upstream
[ INFO    ]: 13:36:32 | --> package: gio-branding-upstream
[ INFO    ]: 13:36:32 | --> package: group(mail)
[ INFO    ]: 13:36:32 | --> package: group(wheel)
[ INFO    ]: 13:36:32 | --> package: grub2
[ INFO    ]: 13:36:32 | --> package: grub2-branding-upstream
[ INFO    ]: 13:36:32 | --> package: grub2-i386-pc
[ INFO    ]: 13:36:32 | --> package: grub2-snapper-plugin
[ INFO    ]: 13:36:32 | --> package: grub2-x86_64-efi
[ INFO    ]: 13:36:32 | --> package: haveged
[ INFO    ]: 13:36:32 | --> package: hdparm
[ INFO    ]: 13:36:32 | --> package: htop
[ INFO    ]: 13:36:32 | --> package: iproute2
[ INFO    ]: 13:36:32 | --> package: iputils
[ INFO    ]: 13:36:32 | --> package: jeos-firstboot
[ INFO    ]: 13:36:32 | --> package: kernel-default
[ INFO    ]: 13:36:32 | --> package: keyutils
[ INFO    ]: 13:36:32 | --> package: krb5-client
[ INFO    ]: 13:36:32 | --> package: less
[ INFO    ]: 13:36:32 | --> package: lsof
[ INFO    ]: 13:36:32 | --> package: nano
[ INFO    ]: 13:36:32 | --> package: net-snmp
[ INFO    ]: 13:36:32 | --> package: nfs-client
[ INFO    ]: 13:36:32 | --> package: nfs-kernel-server
[ INFO    ]: 13:36:32 | --> package: nginx
[ INFO    ]: 13:36:32 | --> package: ntp
[ INFO    ]: 13:36:32 | --> package: nut
[ INFO    ]: 13:36:32 | --> package: nut-drivers-net
[ INFO    ]: 13:36:32 | --> package: open-iscsi
[ INFO    ]: 13:36:32 | --> package: openssh
[ INFO    ]: 13:36:32 | --> package: parted
[ INFO    ]: 13:36:32 | --> package: patterns-base-base
[ INFO    ]: 13:36:32 | --> package: postfix
[ INFO    ]: 13:36:32 | --> package: postgresql10
[ INFO    ]: 13:36:32 | --> package: postgresql10-server
[ INFO    ]: 13:36:32 | --> package: python-xml
[ INFO    ]: 13:36:32 | --> package: python2-chardet
[ INFO    ]: 13:36:32 | --> package: python2-distro
[ INFO    ]: 13:36:32 | --> package: python2-psycopg2
[ INFO    ]: 13:36:32 | --> package: python2-pyzmq
[ INFO    ]: 13:36:32 | --> package: python2-requests
[ INFO    ]: 13:36:32 | --> package: python2-setuptools
[ INFO    ]: 13:36:32 | --> package: python2-six
[ INFO    ]: 13:36:32 | --> package: python3-distro
[ INFO    ]: 13:36:32 | --> package: python3-python-dateutil
[ INFO    ]: 13:36:32 | --> package: realmd
[ INFO    ]: 13:36:32 | --> package: realmd-lang
[ INFO    ]: 13:36:32 | --> package: rockstor-4.0.4-0
[ INFO    ]: 13:36:32 | --> package: rpcbind
[ INFO    ]: 13:36:32 | --> package: rsync
[ INFO    ]: 13:36:32 | --> package: samba
[ INFO    ]: 13:36:32 | --> package: samba-winbind
[ INFO    ]: 13:36:32 | --> package: shellinabox
[ INFO    ]: 13:36:32 | --> package: shim
[ INFO    ]: 13:36:32 | --> package: smartmontools
[ INFO    ]: 13:36:32 | --> package: snapper
[ INFO    ]: 13:36:32 | --> package: snapper-zypp-plugin
[ INFO    ]: 13:36:32 | --> package: syslinux
[ INFO    ]: 13:36:32 | --> package: systemd
[ INFO    ]: 13:36:32 | --> package: systemd-presets-branding
[ INFO    ]: 13:36:32 | --> package: systemd-sysvinit
[ INFO    ]: 13:36:32 | --> package: systemtap-runtime
[ INFO    ]: 13:36:32 | --> package: tar
[ INFO    ]: 13:36:32 | --> package: timezone
[ INFO    ]: 13:36:32 | --> package: vim
[ INFO    ]: 13:36:32 | --> package: which
[ INFO    ]: 13:36:32 | --> package: ypbind
[ INFO    ]: Processing: [########################################] 100%
[ INFO    ]: 13:37:38 | Reading runtime config file: /etc/kiwi.yml
[ INFO    ]: 13:37:38 | Importing Image description to system tree
[ INFO    ]: 13:37:38 | --> Importing state XML description to /home/kiwi-images-dev/build/image-root/image/config.xml
[ INFO    ]: 13:37:38 | --> Importing config.sh script to /home/kiwi-images-dev/build/image-root/image/config.sh
[ INFO    ]: 13:37:38 | --> Importing script helper functions
[ INFO    ]: 13:37:38 | Copying user defined files to image tree
[ INFO    ]: 13:37:38 | Setting up user root
[ INFO    ]: 13:37:38 | --> Modifying user: root
[ INFO    ]: 13:37:38 | --> Primary group for user root: root
[ INFO    ]: 13:37:38 | Setting up keytable: gb
[ INFO    ]: 13:37:38 | Setting up locale: en_GB
[ INFO    ]: 13:37:38 | Setting up timezone: Europe/London
[ INFO    ]: 13:37:38 | Check/Fix File Permissions
[ INFO    ]: 13:37:38 | Reading runtime config file: /etc/kiwi.yml
[ INFO    ]: 13:37:39 | Setting up image repository obs://openSUSE:Leap:15.2/standard
[ INFO    ]: 13:37:39 | --> Type: rpm-md
[ INFO    ]: 13:37:39 | --> Translated: http://download.opensuse.org/distribution/leap/15.2/repo/oss/
[ INFO    ]: 13:37:39 | --> Alias: Leap_15_2
[ INFO    ]: 13:37:39 | Reading runtime config file: /etc/kiwi.yml
[ INFO    ]: 13:37:39 | Reading runtime config file: /etc/kiwi.yml
[ INFO    ]: 13:37:39 | Setting up image repository http://download.opensuse.org/update/leap/15.2/oss/
[ INFO    ]: 13:37:39 | --> Type: rpm-md
[ INFO    ]: 13:37:39 | --> Translated: http://download.opensuse.org/update/leap/15.2/oss/
[ INFO    ]: 13:37:39 | --> Alias: Leap_15_2_Updates
[ INFO    ]: 13:37:39 | Reading runtime config file: /etc/kiwi.yml
[ INFO    ]: 13:37:39 | Reading runtime config file: /etc/kiwi.yml
[ INFO    ]: 13:37:39 | Setting up image repository http://download.opensuse.org/repositories/shells/openSUSE_Leap_15.2/
[ INFO    ]: 13:37:39 | --> Type: rpm-md
[ INFO    ]: 13:37:39 | --> Translated: http://download.opensuse.org/repositories/shells/openSUSE_Leap_15.2/
[ INFO    ]: 13:37:39 | --> Alias: shells
[ INFO    ]: 13:37:39 | Reading runtime config file: /etc/kiwi.yml
[ INFO    ]: 13:37:39 | Reading runtime config file: /etc/kiwi.yml
[ INFO    ]: 13:37:39 | Setting up image repository http://download.opensuse.org/repositories/home:/rockstor:/branches:/Base:/System/openSUSE_Leap_15.2/
[ INFO    ]: 13:37:39 | --> Type: rpm-md
[ INFO    ]: 13:37:39 | --> Translated: http://download.opensuse.org/repositories/home:/rockstor:/branches:/Base:/System/openSUSE_Leap_15.2/
[ INFO    ]: 13:37:39 | --> Alias: home_rockstor_branches_Base_System
[ INFO    ]: 13:37:39 | Reading runtime config file: /etc/kiwi.yml
[ INFO    ]: 13:37:39 | Calling config.sh script
[ INFO    ]: 13:38:27 | Using package manager backend: zypper
[ INFO    ]: 13:38:27 | Cleaning up SystemPrepare instance
[ INFO    ]: 13:38:27 | Creating system image
[ INFO    ]: 13:38:27 | Reading runtime config file: /etc/kiwi.yml
[ INFO    ]: 13:38:27 | Reading runtime config file: /etc/kiwi.yml
[ INFO    ]: 13:38:27 | Reading runtime config file: /etc/kiwi.yml
[ INFO    ]: 13:38:27 | Reading runtime config file: /etc/kiwi.yml
[ INFO    ]: 13:38:27 | Preparing boot system
[ INFO    ]: 13:38:27 | Reading runtime config file: /etc/kiwi.yml
[ INFO    ]: 13:38:27 | Precalculating required disk size
[ INFO    ]: 13:38:28 | --> system data with filesystem overhead needs 2084 MB
[ INFO    ]: 13:38:28 | --> swap partition adding 2048 MB
[ INFO    ]: 13:38:28 | --> legacy bios boot partition adding 2 MB
[ INFO    ]: 13:38:28 | --> EFI partition adding 33 MB
[ INFO    ]: 13:38:28 | Using calculated disk size: 4167 MB
[ INFO    ]: 13:38:28 | Creating raw disk image /home/kiwi-images-dev/Rockstor-NAS.x86_64-4.0.4-0.raw
[ INFO    ]: 13:38:29 | --> creating EFI CSM(legacy bios) partition
[ INFO    ]: 13:38:32 | --> creating EFI partition
[ INFO    ]: 13:38:34 | --> creating SWAP partition
[ INFO    ]: 13:38:36 | --> creating root partition
[ INFO    ]: 13:38:39 | Creating EFI(fat16) filesystem on /dev/mapper/loop6p2
[ INFO    ]: 13:38:39 | Cleaning up FileSystemBtrfs instance
[ INFO    ]: 13:38:39 | Creating btrfs sub volumes
[ INFO    ]: 13:38:39 | --> sub volume home
[ INFO    ]: 13:38:39 | --> sub volume opt
[ INFO    ]: 13:38:39 | --> sub volume root
[ INFO    ]: 13:38:39 | --> sub volume srv
[ INFO    ]: 13:38:39 | --> sub volume tmp
[ INFO    ]: 13:38:39 | --> sub volume var
[ INFO    ]: 13:38:39 | --> setting no-copy-on-write for var
[ INFO    ]: 13:38:39 | --> sub volume usr/local
[ INFO    ]: 13:38:39 | --> sub volume boot/grub2/i386-pc
[ INFO    ]: 13:38:39 | --> sub volume boot/grub2/x86_64-efi
[ INFO    ]: 13:38:40 | Creating config.partids in boot system
[ INFO    ]: 13:38:40 | Export modprobe configuration
[ INFO    ]: 13:38:40 | Creating image identifier: 0x05bf549c
[ INFO    ]: 13:38:40 | Creating generic system etc/fstab
[ INFO    ]: 13:38:40 | Creating generic dracut initrd archive
[ INFO    ]: 13:39:35 | --> initrd archive as initrd-5.3.18-lp152.57-default
[ INFO    ]: 13:39:35 | Creating grub2 bootloader configuration
[ INFO    ]: 13:39:35 | Creating grub2 bootloader images
[ WARNING ]: 13:39:35 | Theme /home/kiwi-images-dev/build/image-root/boot/grub2/themes/upstream not found
[ WARNING ]: 13:39:35 | Set bootloader terminal to console mode
[ INFO    ]: 13:39:35 | --> Using prebuilt unsigned efi image
[ INFO    ]: 13:39:36 | Writing grub2 defaults file
[ INFO    ]: 13:39:36 | --> GRUB_CMDLINE_LINUX_DEFAULT:"ipv6.disable=1 plymouth.enable=0 rd.kiwi.oem.maxdisk=5000G"
[ INFO    ]: 13:39:36 | --> GRUB_GFXMODE:auto
[ INFO    ]: 13:39:36 | --> GRUB_TERMINAL:"console"
[ INFO    ]: 13:39:36 | --> GRUB_THEME:/boot/grub2/themes/upstream/theme.txt
[ INFO    ]: 13:39:36 | --> GRUB_TIMEOUT:10
[ INFO    ]: 13:39:36 | --> GRUB_USE_INITRDEFI:true
[ INFO    ]: 13:39:36 | --> GRUB_USE_LINUXEFI:true
[ INFO    ]: 13:39:36 | --> SUSE_BTRFS_SNAPSHOT_BOOTING:true
[ INFO    ]: 13:39:36 | Writing sysconfig bootloader file
[ INFO    ]: 13:39:36 | --> DEFAULT_APPEND:"ipv6.disable=1 plymouth.enable=0 rd.kiwi.oem.maxdisk=5000G root=UUID=6a2353c1-7183-4f09-81dc-1778b5c5eb66 rw "
[ INFO    ]: 13:39:36 | --> FAILSAFE_APPEND:"ipv6.disable=1 plymouth.enable=0 rd.kiwi.oem.maxdisk=5000G root=UUID=6a2353c1-7183-4f09-81dc-1778b5c5eb66 rw  ide=nodma apm=off noresume edd=off nomodeset 3 "
[ INFO    ]: 13:39:36 | --> LOADER_LOCATION:none
[ INFO    ]: 13:39:36 | --> LOADER_TYPE:grub2-efi
[ INFO    ]: 13:39:36 | Creating config.bootoptions
[ INFO    ]: 13:39:36 | Syncing system to image
[ INFO    ]: 13:39:36 | --> Syncing EFI boot data to EFI partition
[ WARNING ]: 13:39:36 | Extended attributes not supported for target: /tmp/kiwi_mount_manager.s88muyk1
[ INFO    ]: 13:39:36 | --> Syncing root filesystem data
[ INFO    ]: 13:39:51 | Copying /home/kiwi-images-dev/build/image-root/boot/efi/EFI/BOOT/grub.cfg -> /tmp/kiwi_mount_manager.xfxt8zy6/boot/efi/EFI/BOOT/grub.cfg to be found by EFI
[ INFO    ]: 13:39:51 | Cleaning up BootLoaderConfigGrub2 instance
[ INFO    ]: 13:39:52 | Installing grub2 on disk /dev/loop6
[ INFO    ]: 13:40:02 | Cleaning up BootLoaderInstallGrub2 instance
[ INFO    ]: 13:40:02 | Saving boot image instance to file
[ INFO    ]: 13:40:02 | Export rpm packages metadata
[ INFO    ]: 13:40:03 | Export rpm packages changelog metadata
[ INFO    ]: 13:40:04 | Export rpm verification metadata
[ INFO    ]: 13:40:15 | Cleaning up FileSystemSwap instance
[ INFO    ]: 13:40:15 | Cleaning up FileSystemFat16 instance
[ INFO    ]: 13:40:15 | umount FileSystemFat16 instance
[ INFO    ]: 13:40:15 | Cleaning up VolumeManagerBtrfs instance
[ INFO    ]: 13:40:15 | Cleaning up Disk instance
[ INFO    ]: 13:40:15 | Cleaning up LoopDevice instance
[ INFO    ]: 13:40:15 | Reading runtime config file: /etc/kiwi.yml
[ INFO    ]: 13:40:15 | Reading runtime config file: /etc/kiwi.yml
[ INFO    ]: 13:40:15 | Reading runtime config file: /etc/kiwi.yml
[ INFO    ]: 13:40:15 | Creating hybrid ISO installation image
[ INFO    ]: 13:40:15 | Creating disk image checksum
[ INFO    ]: 13:40:25 | Creating squashfs embedded disk image
[ INFO    ]: 13:46:39 | Setting up install image bootloader configuration
[ INFO    ]: 13:46:39 | Creating grub2 bootloader images
[ INFO    ]: 13:46:39 | --> Creating identifier file 0x6c42a445
[ WARNING ]: 13:46:39 | Theme /home/kiwi-images-dev/kiwi_install_media.m63ebjt7/boot/grub2/themes/upstream not found
[ WARNING ]: 13:46:39 | Set bootloader terminal to console mode
[ INFO    ]: 13:46:39 | --> Creating bios image
[ INFO    ]: 13:46:40 | --> Using prebuilt unsigned efi image
[ WARNING ]: 13:46:40 | root=UUID=<uuid> setup requested, but uuid is not provided
[ WARNING ]: 13:46:40 | root=UUID=<uuid> setup requested, but uuid is not provided
[ INFO    ]: 13:46:40 | Writing grub2 defaults file
[ INFO    ]: 13:46:40 | --> GRUB_CMDLINE_LINUX_DEFAULT:"ipv6.disable=1 plymouth.enable=0 rd.kiwi.oem.maxdisk=5000G"
[ INFO    ]: 13:46:40 | --> GRUB_GFXMODE:auto
[ INFO    ]: 13:46:40 | --> GRUB_TERMINAL:"console"
[ INFO    ]: 13:46:40 | --> GRUB_THEME:/boot/grub2/themes/upstream/theme.txt
[ INFO    ]: 13:46:40 | --> GRUB_TIMEOUT:10
[ INFO    ]: 13:46:40 | --> GRUB_USE_INITRDEFI:true
[ INFO    ]: 13:46:40 | --> GRUB_USE_LINUXEFI:true
[ INFO    ]: 13:46:40 | --> SUSE_BTRFS_SNAPSHOT_BOOTING:true
[ INFO    ]: 13:46:40 | Writing sysconfig bootloader file
[ INFO    ]: 13:46:40 | --> DEFAULT_APPEND:"ipv6.disable=1 plymouth.enable=0 rd.kiwi.oem.maxdisk=5000G "
[ INFO    ]: 13:46:40 | --> FAILSAFE_APPEND:"ipv6.disable=1 plymouth.enable=0 rd.kiwi.oem.maxdisk=5000G  ide=nodma apm=off noresume edd=off nomodeset 3 "
[ INFO    ]: 13:46:40 | --> LOADER_LOCATION:none
[ INFO    ]: 13:46:40 | --> LOADER_TYPE:grub2-efi
[ INFO    ]: 13:46:40 | Creating grub2 install config file from template
[ INFO    ]: 13:46:40 | --> Using standard boot install template
[ INFO    ]: 13:46:40 | Writing KIWI template grub.cfg file
[ INFO    ]: 13:46:40 | Creating install image boot image
[ INFO    ]: 13:46:40 | Creating generic dracut initrd archive
[ INFO    ]: 13:47:36 | Creating ISO filesystem
[ INFO    ]: 13:47:36 | Reading runtime config file: /etc/kiwi.yml
[ INFO    ]: 13:47:41 | Cleaning up FileSystemSquashFs instance
[ INFO    ]: 13:47:41 | Cleaning up BootLoaderConfigGrub2 instance
[ INFO    ]: 13:47:41 | Cleaning up FileSystemIsoFs instance
[ INFO    ]: 13:47:41 | Cleaning up InstallImageBuilder instance
[ INFO    ]: 13:47:41 | Reading runtime config file: /etc/kiwi.yml
[ INFO    ]: 13:47:41 | Reading runtime config file: /etc/kiwi.yml
[ INFO    ]: 13:47:41 | Result files:
[ INFO    ]: 13:47:41 | --> disk_image: /home/kiwi-images-dev/Rockstor-NAS.x86_64-4.0.4-0.raw
[ INFO    ]: 13:47:41 | --> image_changes: /home/kiwi-images-dev/Rockstor-NAS.x86_64-4.0.4-0.changes
[ INFO    ]: 13:47:41 | --> image_packages: /home/kiwi-images-dev/Rockstor-NAS.x86_64-4.0.4-0.packages
[ INFO    ]: 13:47:41 | --> image_verified: /home/kiwi-images-dev/Rockstor-NAS.x86_64-4.0.4-0.verified
[ INFO    ]: 13:47:41 | --> installation_image: /home/kiwi-images-dev/Rockstor-NAS.x86_64-4.0.4-0.install.iso
```


</details>
