### PR TITLE
Remove now incompatible factory Arm shells repo - Aarch64 profiles (#44)

### DIFF
--- a/rockstor.kiwi
+++ b/rockstor.kiwi
@@ -297,11 +297,12 @@ which includes aarch64 relevant content -->
                 profiles="Leap15.2.x86_64">
         <source path="http://download.opensuse.org/repositories/shells/openSUSE_Leap_15.2/"/>
     </repository>
-    <!-- TODO: NOT YET AVAILABLE FOR LEAP15.2 aarch64 so use Factory_ARM source for now -->
-    <repository type="rpm-md" alias="shells" priority="105" imageinclude="true"
-                profiles="Leap15.2.RaspberryPi4,Leap15.2.ARM64EFI">
-        <source path="https://download.opensuse.org/repositories/shells/openSUSE_Factory_ARM/"/>
-    </repository>
+    <!-- TODO: NOT YET AVAILABLE FOR LEAP 15.2/15.3 ON aarch64 so using mcbridematt repo for now -->
+    <!-- Previously shells/openSUSE_Factory_ARM worked but glibc updates there now prevent this -->
+    <!--    <repository type="rpm-md" alias="shells" priority="105" imageinclude="true"-->
+    <!--                profiles="Leap15.2.RaspberryPi4,Leap15.2.ARM64EFI">-->
+    <!--        <source path="https://download.opensuse.org/repositories/shells/openSUSE_Factory_ARM/"/>-->
+    <!--    </repository>-->
     <repository type="rpm-md" alias="shells" priority="105" imageinclude="true"
                 profiles="Tumbleweed.x86_64">
         <source path="http://download.opensuse.org/repositories/shells/openSUSE_Tumbleweed/"/>
@@ -328,9 +329,10 @@ which includes aarch64 relevant content -->
                 profiles="Tumbleweed.x86_64">
         <source path="http://download.opensuse.org/repositories/home:/rockstor:/branches:/Base:/System/openSUSE_Factory/"/>
     </repository>
-    <!-- For Traverse Ten64 drivers -->
+    <!-- For Traverse Ten64 drivers and aarch64 shellinabox (while no aarch64 shells repo exists) -->
+    <!-- https://build.opensuse.org/project/show/home:mcbridematt  -->
     <repository type="rpm-md" alias="mcbridematt" imageinclude="true"
-                profiles="Leap15.2.ARM64EFI">
+                profiles="Leap15.2.ARM64EFI,Leap15.2.RaspberryPi4,">
         <source path="obs://home:mcbridematt/openSUSE_Leap_15.2/" />
     </repository>
     <packages type="image">


### PR DESCRIPTION
Since the upstream factory arm repo moved to a newer version of glibc we can no longer use it for our Arm shellinabox dependency. For now use mcbridematt arm specific repo as this has a proven working shellinabox.

X86_64 profiles are not affected by this as they have upstream 'shells' repos available.

Fixes #44 

N.B. The prior config did however work for the Leap15.2.ARM64EFI profile as it already had the mcbridematt repo configured for the Ten64 drivers requirement. Hence an alternative working shellinabox was available to that profile where it was not for the Leap15.2.RaspberryPi4 profile, which is also an aarch64 based target.