### PR TITLE
Remove EoL Leap15.1.x86_64 profile (#21)

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,7 +30,6 @@ We can make no promises for the 'supported' status of any additional profiles bu
 ## Current Profiles
 
 ### Working Profiles:
-- **Leap15.1.x86_64**
 - **Leap15.2.x86_64** (recommended) - proposed for our Rockstor 4 're-launch')
 - **Leap15.2.RaspberryPi4**
 - **Leap15.2.ARM64EFI**

--- a/_multibuild
+++ b/_multibuild
@@ -1,5 +1,4 @@
 <multibuild>
   <flavor>Leap15.2.x86_64</flavor>
-  <flavor>Leap15.1.x86_64</flavor>
   <flavor>Leap15.2.RaspberryPi4</flavor>
 </multibuild>

--- a/rockstor.kiwi
+++ b/rockstor.kiwi
@@ -2,7 +2,6 @@
 <!-- schema doc available at:
 https://osinside.github.io/kiwi/development/schema.html#schema-docs -->
 <!-- For reference we have:
-https://build.opensuse.org/package/show/openSUSE:Leap:15.1:Images:ToTest/openSUSE-Leap-15.1-JeOS
 https://build.opensuse.org/project/show/Virtualization:Appliances:Images:openSUSE-Leap-15.2
 https://build.opensuse.org/package/view_file/Virtualization:Appliances:Images:openSUSE-Leap-15.2/kiwi-templates-JeOS/JeOS.kiwi
 https://build.opensuse.org/project/show/Virtualization:Appliances:Images:openSUSE-Tumbleweed
@@ -25,16 +24,8 @@ which includes aarch64 relevant content -->
         <!-- For preferences, drivers, repository, packages, and users elements -->
         <!-- https://osinside.github.io/kiwi/working_with_kiwi/xml_description.html#image-profiles-->
         <!-- N.B. can inherit one profile within another via requires profile="" -->
-        <profile name="Leap15.1.x86_64"
-                 description="Rockstor built on openSUSE Leap 15.1 x86_64"
-                 arch="x86_64"/>
         <profile name="Leap15.2.x86_64"
                  description="Rockstor built on openSUSE Leap 15.2 x86_64"
-                 arch="x86_64"/>
-        <!-- Tumbleweed.x86_64 profile currently broken due to now missing python2 dependencies -->
-        <!-- maintaining for use testing Python 3 migration within testing channel -->
-        <profile name="Tumbleweed.x86_64"
-                 description="Rockstor built on openSUSE Tumbleweed x86_64"
                  arch="x86_64"/>
         <profile name="Leap15.2.RaspberryPi4"
                  description="Rockstor built on openSUSE Leap 15.2 Raspberry_Pi"
@@ -42,8 +33,13 @@ which includes aarch64 relevant content -->
         <profile name="Leap15.2.ARM64EFI"
                          description="Rockstor built on openSUSE Leap 15.2 ARM64 EFI/VM/Ten64"
                          arch="aarch64"/>
+        <!-- Tumbleweed.x86_64 profile currently broken due to now missing python2 dependencies -->
+        <!-- maintaining for use testing Python 3 migration within testing channel -->
+        <profile name="Tumbleweed.x86_64"
+                 description="Rockstor built on openSUSE Tumbleweed x86_64"
+                 arch="x86_64"/>
     </profiles>
-    <preferences profiles="Leap15.1.x86_64,Leap15.2.x86_64,Tumbleweed.x86_64">
+    <preferences profiles="Leap15.2.x86_64,Tumbleweed.x86_64">
         <!--Change to reflect the Rockstor version used #.#.# (rpm version) -# (rpm release)-->
         <version>4.0.4-0</version>
         <packagemanager>zypper</packagemanager>
@@ -213,10 +209,6 @@ which includes aarch64 relevant content -->
     </users>
     <!-- For zypper priority 1 is highest, priority 0 returns to default of 99 -->
     <repository type="rpm-md" alias="kiwi" priority="1"
-                profiles="Leap15.1.x86_64">
-        <source path="obs://Virtualization:Appliances:Builder/openSUSE_Leap_15.1"/>
-    </repository>
-    <repository type="rpm-md" alias="kiwi" priority="1"
                 profiles="Leap15.2.x86_64">
         <source path="obs://Virtualization:Appliances:Builder/openSUSE_Leap_15.2"/>
     </repository>
@@ -230,10 +222,6 @@ which includes aarch64 relevant content -->
     </repository>
     <!-- https://en.opensuse.org/Package_repositories -->
     <!-- Alias repo-oss Name="Main Repository" in JeOS-->
-    <repository type="rpm-md" alias="Leap_15_1" imageinclude="true"
-                profiles="Leap15.1.x86_64">
-        <source path="obs://openSUSE:Leap:15.1/standard"/>
-    </repository>
     <repository type="rpm-md" alias="Leap_15_2" imageinclude="true"
                 profiles="Leap15.2.x86_64">
         <source path="obs://openSUSE:Leap:15.2/standard"/>
@@ -247,10 +235,6 @@ which includes aarch64 relevant content -->
         <source path="obs://openSUSE:Tumbleweed/standard"/>
     </repository>
     <!-- Alias repo-update Name="Main Update Repository" or "openSUSE-Tumbleweed-Update" in JeOS-->
-    <repository type="rpm-md" alias="Leap_15_1_Updates" imageinclude="true"
-                profiles="Leap15.1.x86_64">
-        <source path="http://download.opensuse.org/update/leap/15.1/oss/"/>
-    </repository>
     <repository type="rpm-md" alias="Leap_15_2_Updates" imageinclude="true"
                 profiles="Leap15.2.x86_64">
         <source path="http://download.opensuse.org/update/leap/15.2/oss/"/>
@@ -268,11 +252,7 @@ which includes aarch64 relevant content -->
     <!--    <repository type="rpm-dir" alias="Local-Repository">-->
     <!--        <source path="dir:/mnt/localrepo"/>-->
     <!--    </repository>-->
-    <!-- Resource Rockstor Testing channel until Stable for openSUSE is released -->
-    <repository type="rpm-md" alias="Rockstor-Testing"
-                profiles="Leap15.1.x86_64">
-        <source path="http://updates.rockstor.com:8999/rockstor-testing/leap/15.1/"/>
-    </repository>
+    <!-- Resource Rockstor Testing channel during installer build only -->
     <repository type="rpm-md" alias="Rockstor-Testing"
                 profiles="Leap15.2.x86_64">
         <source path="http://updates.rockstor.com:8999/rockstor-testing/leap/15.2/"/>
@@ -289,10 +269,6 @@ which includes aarch64 relevant content -->
     <!-- https://build.opensuse.org/package/show/shells/shellinabox -->
     <!-- Lower priority (higher number) than default 99 to avoid other dev shell packages supplanting -->
     <!-- those in default repositories. Shellinabox is not currently offered as part of the base system -->
-    <repository type="rpm-md" alias="shells" priority="105" imageinclude="true"
-                profiles="Leap15.1.x86_64">
-        <source path="http://download.opensuse.org/repositories/shells/openSUSE_Leap_15.1/"/>
-    </repository>
     <repository type="rpm-md" alias="shells" priority="105" imageinclude="true"
                 profiles="Leap15.2.x86_64">
         <source path="http://download.opensuse.org/repositories/shells/openSUSE_Leap_15.2/"/>
@@ -311,10 +287,6 @@ which includes aarch64 relevant content -->
     <!-- We are required to de/re-brand packages that have no "...branding-upstream" equivalent-->
     <!-- This repo currently provides: systemd-presets-branding-rockstor -->
     <!-- https://build.opensuse.org/package/show/home:rockstor:branches:Base:System/systemd-presets-branding-rockstor -->
-    <repository type="rpm-md" alias="home_rockstor_branches_Base_System" priority="97" imageinclude="true"
-                profiles="Leap15.1.x86_64">
-        <source path="http://download.opensuse.org/repositories/home:/rockstor:/branches:/Base:/System/openSUSE_Leap_15.1/"/>
-    </repository>
     <repository type="rpm-md" alias="home_rockstor_branches_Base_System" priority="97" imageinclude="true"
                 profiles="Leap15.2.x86_64,Leap15.2.ARM64EFI">
         <source path="http://download.opensuse.org/repositories/home:/rockstor:/branches:/Base:/System/openSUSE_Leap_15.2/"/>


### PR DESCRIPTION
Remove the Leap 15.1 profile (was x86_64 only) and update the Readme & _multibuild files accordingly.

Fixes #21 

Please see issue text for context.

Contains a minor re-ordering to aid readability: putting the placeholder Tumbleweed profile last.