### PR TITLE
Update RaspberryPi4 profile (#50)

### DIFF
--- a/rockstor.kiwi
+++ b/rockstor.kiwi
@@ -412,6 +412,8 @@ which includes aarch64 relevant content -->
         <package name="timezone"/>
         <package name="vim"/>
         <package name="which"/>
+        <!-- Fix choice between kernel-firmware and kernel-firmware-all -->
+        <!-- <package name="kernel-firmware"/> -->
         <!--ADDITIONAL ROCKSTOR DEPENDENCIES-->
         <package name="at"/>
         <package name="avahi"/>
@@ -458,13 +460,12 @@ which includes aarch64 relevant content -->
         <package name="rockstor-4.0.4-0"/>
     </packages>
     <packages type="image" profiles="Leap15.2.RaspberryPi4,Leap15.3.RaspberryPi4">
+        <package name="raspberrypi-eeprom" arch="aarch64"/>
         <package name="raspberrypi-firmware" arch="aarch64"/>
         <package name="raspberrypi-firmware-config" arch="aarch64"/>
         <package name="raspberrypi-firmware-dt" arch="aarch64"/>
         <!-- For WiFi: -->
         <package name="bcm43xx-firmware"/>
-        <package
-                name="kernel-firmware"/><!-- Fix choice between kernel-firmware and kernel-firmware-all -->
         <package name="u-boot-rpiarm64" arch="aarch64"/>
     </packages>
     <packages type="image" profiles="Leap15.2.ARM64EFI">


### PR DESCRIPTION
Fixes #50 
@phillxnet , ready for review.

This small pull request (PR) applies the changes discussed in #50:
- remove `kernel-firmware` package
- add `raspberrypi-eeprom` package

Note that the removal of `kernel-firmware` drastically reduces the final image size. From kiwi build log, we can see:
```
INFO: 13:33:23 | --> system data with filesystem overhead needs 2103 MB
INFO: 13:33:23 | --> swap partition adding 2048 MB
INFO: 13:33:23 | --> EFI partition adding 64 MB
INFO: 13:33:23 | Using calculated disk size: 4215 MB
```

The latter was 5.1 **GB** prior to this PR.

This was built using kiwi **version 9.23.31**:
```
# kiwi-ng --version
KIWI (next generation) version 9.23.31
```
The resulting `.raw` image was tested in a KVM VM: it booted, rebooted, and could complete the Rockstor first login procedure successfully.