### PR TITLE
Remove call to deprecated BaseMount/BaseCleanMount functions (#52)

### DIFF
--- a/config.sh
+++ b/config.sh
@@ -19,11 +19,6 @@ test -f /.profile && . /.profile
 echo "Configure image: [$kiwi_iname]..."
 
 #======================================
-# Mount system filesystems
-#--------------------------------------
-baseMount
-
-#======================================
 # Setup baseproduct link
 #--------------------------------------
 suseSetupProduct
@@ -186,10 +181,5 @@ echo >> /etc/default/grub
 echo "# Set distributor for custom menu text" >> /etc/default/grub
 echo 'GRUB_DISTRIBUTOR="Rockstor NAS"' >> /etc/default/grub
 echo >> /etc/default/grub
-
-#======================================
-# Umount kernel filesystems
-#--------------------------------------
-baseCleanMount
 
 exit 0


### PR DESCRIPTION
Fixes #52 
@phillxnet , I'm submitting this PR as draft for now so that I can more easily test build the installer in all our targets. Once I have verified it still works well in all of them, I'll update its status.

As described in #52, we currently call the now-deprecated`BaseMount` and `BaseCleanMount` functions. This pull request simply proposes to remove these calls.