### PR TITLE
Move default iso/rockstor rpm version to 4.0.7-0 #57

### DIFF
--- a/rockstor.kiwi
+++ b/rockstor.kiwi
@@ -50,7 +50,7 @@ which includes aarch64 relevant content -->
     </profiles>
     <preferences profiles="Leap15.2.x86_64,Leap15.3.x86_64,Tumbleweed.x86_64">
         <!--Change to reflect the Rockstor version used #.#.# (rpm version) -# (rpm release)-->
-        <version>4.0.4-0</version>
+        <version>4.0.7-0</version>
         <packagemanager>zypper</packagemanager>
         <locale>en_GB</locale>
         <keytable>gb</keytable>
@@ -105,7 +105,7 @@ which includes aarch64 relevant content -->
 
     <preferences profiles="Leap15.2.RaspberryPi4,Leap15.3.RaspberryPi4">
         <!--Change to reflect the Rockstor version used #.#.# (rpm version) -# (rpm release)-->
-        <version>4.0.4-0</version>
+        <version>4.0.7-0</version>
         <packagemanager>zypper</packagemanager>
         <locale>en_GB</locale>
         <keytable>gb</keytable>
@@ -156,7 +156,7 @@ which includes aarch64 relevant content -->
     </preferences>
     <preferences profiles="Leap15.2.ARM64EFI,Leap15.3.ARM64EFI">
         <!--Change to reflect the Rockstor version used #.#.# (rpm version) -# (rpm release)-->
-        <version>4.0.4-0</version>
+        <version>4.0.7-0</version>
         <packagemanager>zypper</packagemanager>
         <locale>en_GB</locale>
         <keytable>gb</keytable>
@@ -456,8 +456,8 @@ which includes aarch64 relevant content -->
         <package name="systemtap-runtime"/>
         <package name="ypbind"/>
         <!--ROCKSTOR PACKAGE-->
-        <!--Change to reflect the version specified, i.e. 4.0.4-0-->
-        <package name="rockstor-4.0.4-0"/>
+        <!--Change to reflect the version specified, i.e. 4.0.7-0-->
+        <package name="rockstor-4.0.7-0"/>
     </packages>
     <packages type="image" profiles="Leap15.2.RaspberryPi4,Leap15.3.RaspberryPi4">
         <package name="raspberrypi-eeprom" arch="aarch64"/>


### PR DESCRIPTION
Our latest available testing rpm is now 4.0.7-0 and given it's positive reports on our forum it now looks ready to be promoted to the default used in out installer build (pre-edit). Note that our prior use of 4.0.0-0 and in-turn 4.0.4-0 were instrumental in testing our now zypper based updates as newer rpms were release. The former indicating a failure initially in updates, and the latter proving the fix.

Fixes #57 
@FroggyFlox Ready for review

