### PR TITLE
Make Pi4 specific packages OS contextual - raspberrypi-eeprom is Leap 15.3 only #63

### DIFF
--- a/rockstor.kiwi
+++ b/rockstor.kiwi
@@ -335,10 +335,6 @@ which includes aarch64 relevant content -->
                 profiles="Leap15.2.RaspberryPi4,Leap15.2.ARM64EFI">
         <source path="https://download.opensuse.org/repositories/home:/rockstor:/branches:/Base:/System/openSUSE_Leap_15.2_ARM/"/>
     </repository>
-    <repository type="rpm-md" alias="pi-eeprom" priority="97" imageinclude="true"
-                profiles="Leap15.2.RaspberryPi4,Leap15.2.ARM64EFI">
-        <source path="https://download.opensuse.org/repositories/hardware:/boot/openSUSE_Factory_ARM/"/>
-    </repository>
     <!-- Leap 15.3 repo now multi architecture -->
     <repository type="rpm-md" alias="home_rockstor_branches_Base_System" priority="97" imageinclude="true"
                 profiles="Leap15.3.x86_64,Leap15.3.RaspberryPi4,Leap15.3.ARM64EFI">
@@ -464,7 +460,6 @@ which includes aarch64 relevant content -->
         <package name="rockstor-4.0.7-0"/>
     </packages>
     <packages type="image" profiles="Leap15.2.RaspberryPi4,Leap15.3.RaspberryPi4">
-        <package name="raspberrypi-eeprom" arch="aarch64"/>
         <package name="raspberrypi-firmware" arch="aarch64"/>
         <package name="raspberrypi-firmware-config" arch="aarch64"/>
         <package name="raspberrypi-firmware-dt" arch="aarch64"/>

--- a/rockstor.kiwi
+++ b/rockstor.kiwi
@@ -459,7 +459,16 @@ which includes aarch64 relevant content -->
         <!--Change to reflect the version specified, i.e. 4.0.7-0-->
         <package name="rockstor-4.0.7-0"/>
     </packages>
-    <packages type="image" profiles="Leap15.2.RaspberryPi4,Leap15.3.RaspberryPi4">
+    <packages type="image" profiles="Leap15.2.RaspberryPi4">
+        <package name="raspberrypi-firmware" arch="aarch64"/>
+        <package name="raspberrypi-firmware-config" arch="aarch64"/>
+        <package name="raspberrypi-firmware-dt" arch="aarch64"/>
+        <!-- For WiFi: -->
+        <package name="bcm43xx-firmware"/>
+        <package name="u-boot-rpiarm64" arch="aarch64"/>
+    </packages>
+    <packages type="image" profiles="Leap15.3.RaspberryPi4">
+        <package name="raspberrypi-eeprom" arch="aarch64"/>
         <package name="raspberrypi-firmware" arch="aarch64"/>
         <package name="raspberrypi-firmware-config" arch="aarch64"/>
         <package name="raspberrypi-firmware-dt" arch="aarch64"/>

--- a/rockstor.kiwi
+++ b/rockstor.kiwi
@@ -335,6 +335,10 @@ which includes aarch64 relevant content -->
                 profiles="Leap15.2.RaspberryPi4,Leap15.2.ARM64EFI">
         <source path="https://download.opensuse.org/repositories/home:/rockstor:/branches:/Base:/System/openSUSE_Leap_15.2_ARM/"/>
     </repository>
+    <repository type="rpm-md" alias="pi-eeprom" priority="97" imageinclude="true"
+                profiles="Leap15.2.RaspberryPi4,Leap15.2.ARM64EFI">
+        <source path="https://download.opensuse.org/repositories/hardware:/boot/openSUSE_Factory_ARM/"/>
+    </repository>
     <!-- Leap 15.3 repo now multi architecture -->
     <repository type="rpm-md" alias="home_rockstor_branches_Base_System" priority="97" imageinclude="true"
                 profiles="Leap15.3.x86_64,Leap15.3.RaspberryPi4,Leap15.3.ARM64EFI">


### PR DESCRIPTION
Fixes raspberrypi-eeprom provider not found error when compiling for Pi4 using Leap 15.2 based profile.

Fixes #63 