### PR TITLE
Normalise efipartsize across profiles #61

### DIFF
--- a/rockstor.kiwi
+++ b/rockstor.kiwi
@@ -79,7 +79,7 @@ which includes aarch64 relevant content -->
                 devicepersistency="by-label"
                 btrfs_root_is_snapshot="true"
                 btrfs_quota_groups="false"
-                efipartsize="33"
+                efipartsize="64"
         >
             <systemdisk>
                 <volume name="home"/>


### PR DESCRIPTION
RaspberryPi4 & ARM64EFI profile variants (Leap 15.2/15.3) set an EFI partition size of 64 MB, where as the x86_64 profile variants set an EFI partition size of 33 MB. Normalise on 64 MB to be on the safe side.

Fixes #61
