### PR TITLE
Correct initial boot message re Started/Finished #66

### DIFF
--- a/root/etc/issue
+++ b/root/etc/issue
@@ -1,7 +1,7 @@
 Welcome to Rockstor built on openSUSE - Kernel \r (\l).
 
 Your Web-UI should be available directly after:
-"[  OK  ] Started Rockstor bootstrapping tasks."
+"[  OK  ] Finished Rockstor bootstrapping tasks."
 appears below.
 
 First login here as the 'root' user for further instructions.


### PR DESCRIPTION
Fixes #66 

The actual message indicating the Web-UI's availability is:
"[  OK  ] Finished Rockstor bootstrapping tasks."
Adjust from prior:
"[  OK  ] Started Rockstor bootstrapping tasks."
within our /etc/issues override.