### PR TITLE
Fix Pi4 log spam when sdcard slot is empty #69

### DIFF
--- a/root/boot/efi/extraconfig.txt
+++ b/root/boot/efi/extraconfig.txt
@@ -1,0 +1,14 @@
+# Added by the Rockstor-installer
+# See: https://github.com/rockstor/rockstor-installer
+#
+# Get more options/information on http://elinux.org/RPiconfig
+# or on https://www.raspberrypi.org/documentation/configuration/config-txt.md
+#
+# !!!!! This file is an updates safe addition to config.txt   !!!!!
+# !!!!!  via that file's "include extraconfig.txt" option.    !!!!!
+# !!!!! For Additional configuration options or dt overlays.  !!!!!
+
+# Avoid log spam with empty sdcard reader.
+# See: https://github.com/raspberrypi/linux/issues/3092
+# N.B. this will also disable sdcard polling after the one time boot poll.
+dtparam=sd_poll_once=on


### PR DESCRIPTION
Adds the included in config.txt, but otherwise nonexistent extraconfig.txt file for user Pi4 config additions that are update safe.
Includes "dtparam=sd_poll_once=on" option to avoid log spamming when USB booting with an empty sdcard adapter.

Fixes #69 

@FroggyFlox Not yet ready for review, just lining up so I can do a test installer build.