### PR TITLE
Update default version to 4.0.8-0 #77

### DIFF
--- a/rockstor.kiwi
+++ b/rockstor.kiwi
@@ -50,7 +50,7 @@ which includes aarch64 relevant content -->
     </profiles>
     <preferences profiles="Leap15.2.x86_64,Leap15.3.x86_64,Tumbleweed.x86_64">
         <!--Change to reflect the Rockstor version used #.#.# (rpm version) -# (rpm release)-->
-        <version>4.0.7-0</version>
+        <version>4.0.8-0</version>
         <packagemanager>zypper</packagemanager>
         <locale>en_GB</locale>
         <keytable>gb</keytable>
@@ -105,7 +105,7 @@ which includes aarch64 relevant content -->
 
     <preferences profiles="Leap15.2.RaspberryPi4,Leap15.3.RaspberryPi4">
         <!--Change to reflect the Rockstor version used #.#.# (rpm version) -# (rpm release)-->
-        <version>4.0.7-0</version>
+        <version>4.0.8-0</version>
         <packagemanager>zypper</packagemanager>
         <locale>en_GB</locale>
         <keytable>gb</keytable>
@@ -156,7 +156,7 @@ which includes aarch64 relevant content -->
     </preferences>
     <preferences profiles="Leap15.2.ARM64EFI,Leap15.3.ARM64EFI">
         <!--Change to reflect the Rockstor version used #.#.# (rpm version) -# (rpm release)-->
-        <version>4.0.7-0</version>
+        <version>4.0.8-0</version>
         <packagemanager>zypper</packagemanager>
         <locale>en_GB</locale>
         <keytable>gb</keytable>
@@ -472,8 +472,8 @@ which includes aarch64 relevant content -->
         <package name="systemtap-runtime"/>
         <package name="ypbind"/>
         <!--ROCKSTOR PACKAGE-->
-        <!--Change to reflect the version specified, i.e. 4.0.7-0-->
-        <package name="rockstor-4.0.7-0"/>
+        <!--Change to reflect the version specified, i.e. 4.0.8-0-->
+        <package name="rockstor-4.0.8-0"/>
     </packages>
     <packages type="image" profiles="Leap15.2.RaspberryPi4">
         <package name="raspberrypi-firmware" arch="aarch64"/>


### PR DESCRIPTION
Update to latest Stable V4 release candidate 9. Predominantly to include the https Rock-on definition retrieval.

Fixes #77