### PR TITLE
Add remarked out 'latest kernel' repo #86

### DIFF
--- a/rockstor.kiwi
+++ b/rockstor.kiwi
@@ -374,20 +374,15 @@ which includes aarch64 relevant content -->
     </repository>
     <!-- THE FOLLOWING KERNEL REPOS ARE NOT SUPPORTED. -->
     <!-- Provided here remarked-out for developer convenience only. -->
-    <!-- Kernel HEAD -->
     <!-- https://doc.opensuse.org/documentation/leap/reference/html/book-reference/cha-tuning-multikernel.html -->
     <!-- "Installing a kernel from Kernel:HEAD should never be necessary, -->
     <!-- because important fixes are backported by SUSE and are made available as official updates. -->
     <!-- Installing the latest kernel only makes sense for kernel developers and kernel testers."-->
-    <!-- ARM -->
-    <repository type="rpm-md" alias="Kernel_HEAD" imageinclude="true"
-                profiles="Leap15.3.RaspberryPi4,Leap15.3.ARM64EFI">
-        <source path="https://download.opensuse.org/repositories/Kernel:/HEAD/ARM/"/>
-    </repository>
-    <!-- X86_64 -->
-    <repository type="rpm-md" alias="Kernel_HEAD" imageinclude="true"
-                profiles="Leap15.3.x86_64">
-        <source path="https://download.opensuse.org/repositories/Kernel:/HEAD/standard/"/>
+    <!-- https://build.opensuse.org/repositories/Kernel:HEAD:Backport -->
+    <!-- Kernel HEAD Backports -->
+    <repository type="rpm-md" alias="Kernel_HEAD_Backport" imageinclude="true"
+                profiles="Leap15.3.x86_64,Leap15.3.RaspberryPi4,Leap15.3.ARM64EFI">
+        <source path="https://download.opensuse.org/repositories/Kernel:/HEAD:/Backport/standard/"/>
     </repository>
     <!-- Kernel Stable Backports -->
     <!-- https://build.opensuse.org/project/show/Kernel:stable:Backport -->
@@ -402,12 +397,10 @@ which includes aarch64 relevant content -->
                 profiles="Leap15.3.x86_64">
         <source path="https://download.opensuse.org/repositories/filesystems/openSUSE_Leap_15.3/"/>
     </repository>
-    <!-- WARNING this is a tumbleweed repo as no ARM64 available for 15.3 in filesystems -->
+    <!-- the following arm repo for filesystems is untested -->
     <repository type="rpm-md" alias="filesystems" imageinclude="true"
                 profiles="Leap15.3.RaspberryPi4,Leap15.3.ARM64EFI">
-        <source path="https://download.opensuse.org/repositories/filesystems/openSUSE_Tumbleweed/"/>
-        <!-- alt multi arch from SLE 15.2 as closer than TW is to Leap 15.3 -->
-        <!-- <source path="https://download.opensuse.org/repositories/filesystems/SLE_15_SP2/"/> -->
+        <source path="https://download.opensuse.org/repositories/filesystems/SLE_15_SP2/"/>
     </repository>
     <packages type="image">
         <package name="adaptec-firmware"/>  <!--Razor AIC94xx Series SAS-->

--- a/rockstor.kiwi
+++ b/rockstor.kiwi
@@ -395,7 +395,7 @@ which includes aarch64 relevant content -->
     <!-- https://build.opensuse.org/project/show/filesystems -->
     <repository type="rpm-md" alias="filesystems" imageinclude="true"
                 profiles="Leap15.3.x86_64,Leap15.3.RaspberryPi4,Leap15.3.ARM64EFI">
-        <source path="https://download.opensuse.org/repositories/filesystems/openSUSE_Leap_15.3/"/>
+        <source path="https://download.opensuse.org/repositories/filesystems/15.3/"/>
     </repository>
     <packages type="image">
         <package name="adaptec-firmware"/>  <!--Razor AIC94xx Series SAS-->

--- a/rockstor.kiwi
+++ b/rockstor.kiwi
@@ -386,7 +386,7 @@ which includes aarch64 relevant content -->
     </repository>
     <!-- Kernel Stable Backports -->
     <!-- https://build.opensuse.org/project/show/Kernel:stable:Backport -->
-    <!-- Multi arch  -->
+    <!-- See also: https://rockstor.com/docs/howtos/stable_kernel_backport.html  -->
     <!--    <repository type="rpm-md" alias="Kernel_stable_Backport" imageinclude="true"-->
     <!--                profiles="Leap15.3.x86_64,Leap15.3.RaspberryPi4,Leap15.3.ARM64EFI">-->
     <!--        <source path="https://download.opensuse.org/repositories/Kernel:/stable:/Backport/standard/"/>-->

--- a/rockstor.kiwi
+++ b/rockstor.kiwi
@@ -387,16 +387,16 @@ which includes aarch64 relevant content -->
     <!-- Kernel Stable Backports -->
     <!-- https://build.opensuse.org/project/show/Kernel:stable:Backport -->
     <!-- See also: https://rockstor.com/docs/howtos/stable_kernel_backport.html  -->
-    <repository type="rpm-md" alias="Kernel_stable_Backport" imageinclude="true"
-                profiles="Leap15.3.x86_64,Leap15.3.RaspberryPi4,Leap15.3.ARM64EFI">
-        <source path="https://download.opensuse.org/repositories/Kernel:/stable:/Backport/standard/"/>
-    </repository>
+    <!--    <repository type="rpm-md" alias="Kernel_stable_Backport" imageinclude="true"-->
+    <!--                profiles="Leap15.3.x86_64,Leap15.3.RaspberryPi4,Leap15.3.ARM64EFI">-->
+    <!--        <source path="https://download.opensuse.org/repositories/Kernel:/stable:/Backport/standard/"/>-->
+    <!--    </repository>-->
     <!-- btrfs-progs backport via filesystems repo -->
     <!-- https://build.opensuse.org/project/show/filesystems -->
-    <repository type="rpm-md" alias="filesystems" imageinclude="true"
-                profiles="Leap15.3.x86_64,Leap15.3.RaspberryPi4,Leap15.3.ARM64EFI">
-        <source path="https://download.opensuse.org/repositories/filesystems/15.3/"/>
-    </repository>
+    <!--    <repository type="rpm-md" alias="filesystems" imageinclude="true"-->
+    <!--                profiles="Leap15.3.x86_64,Leap15.3.RaspberryPi4,Leap15.3.ARM64EFI">-->
+    <!--        <source path="https://download.opensuse.org/repositories/filesystems/15.3/"/>-->
+    <!--    </repository>-->
     <packages type="image">
         <package name="adaptec-firmware"/>  <!--Razor AIC94xx Series SAS-->
         <package name="bash-completion"/>

--- a/rockstor.kiwi
+++ b/rockstor.kiwi
@@ -372,6 +372,43 @@ which includes aarch64 relevant content -->
                 profiles="Leap15.3.ARM64EFI">
         <source path="obs://home:mcbridematt/openSUSE_Leap_15.3/" />
     </repository>
+    <!-- THE FOLLOWING KERNEL REPOS ARE NOT SUPPORTED. -->
+    <!-- Provided here remarked-out for developer convenience only. -->
+    <!-- Kernel HEAD -->
+    <!-- https://doc.opensuse.org/documentation/leap/reference/html/book-reference/cha-tuning-multikernel.html -->
+    <!-- "Installing a kernel from Kernel:HEAD should never be necessary, -->
+    <!-- because important fixes are backported by SUSE and are made available as official updates. -->
+    <!-- Installing the latest kernel only makes sense for kernel developers and kernel testers."-->
+    <!-- ARM -->
+    <!--    <repository type="rpm-md" alias="Kernel_HEAD" imageinclude="true"-->
+    <!--                profiles="Leap15.3.RaspberryPi4,Leap15.3.ARM64EFI">-->
+    <!--        <source path="https://download.opensuse.org/repositories/Kernel:/HEAD/ARM/"/>-->
+    <!--    </repository>-->
+    <!-- X86_64 -->
+    <!--    <repository type="rpm-md" alias="Kernel_HEAD" imageinclude="true"-->
+    <!--                profiles="Leap15.3.x86_64">-->
+    <!--        <source path="https://download.opensuse.org/repositories/Kernel:/HEAD/standard/"/>-->
+    <!--    </repository>-->
+    <!-- Kernel Stable Backports -->
+    <!-- https://build.opensuse.org/project/show/Kernel:stable:Backport -->
+    <!-- Multi arch  -->
+    <repository type="rpm-md" alias="Kernel_stable_Backport" imageinclude="true"
+                profiles="Leap15.3.x86_64,Leap15.3.RaspberryPi4,Leap15.3.ARM64EFI">
+        <source path="https://download.opensuse.org/repositories/Kernel:/stable:/Backport/standard/"/>
+    </repository>
+    <!-- btrfs-progs backport via filesystems repo -->
+    <!-- https://build.opensuse.org/project/show/filesystems -->
+    <repository type="rpm-md" alias="filesystems" imageinclude="true"
+                profiles="Leap15.3.x86_64">
+        <source path="https://download.opensuse.org/repositories/filesystems/openSUSE_Leap_15.3/"/>
+    </repository>
+    <!-- WARNING this is a tumbleweed repo as no ARM64 available for 15.3 in filesystems -->
+    <repository type="rpm-md" alias="filesystems" imageinclude="true"
+                profiles="Leap15.3.RaspberryPi4,Leap15.3.ARM64EFI">
+        <source path="https://download.opensuse.org/repositories/filesystems/openSUSE_Tumbleweed/"/>
+        <!-- alt multi arch from SLE 15.2 as closer than TW is to Leap 15.3 -->
+        <!-- <source path="https://download.opensuse.org/repositories/filesystems/SLE_15_SP2/"/> -->
+    </repository>
     <packages type="image">
         <package name="adaptec-firmware"/>  <!--Razor AIC94xx Series SAS-->
         <package name="bash-completion"/>

--- a/rockstor.kiwi
+++ b/rockstor.kiwi
@@ -380,22 +380,22 @@ which includes aarch64 relevant content -->
     <!-- because important fixes are backported by SUSE and are made available as official updates. -->
     <!-- Installing the latest kernel only makes sense for kernel developers and kernel testers."-->
     <!-- ARM -->
-    <!--    <repository type="rpm-md" alias="Kernel_HEAD" imageinclude="true"-->
-    <!--                profiles="Leap15.3.RaspberryPi4,Leap15.3.ARM64EFI">-->
-    <!--        <source path="https://download.opensuse.org/repositories/Kernel:/HEAD/ARM/"/>-->
-    <!--    </repository>-->
+    <repository type="rpm-md" alias="Kernel_HEAD" imageinclude="true"
+                profiles="Leap15.3.RaspberryPi4,Leap15.3.ARM64EFI">
+        <source path="https://download.opensuse.org/repositories/Kernel:/HEAD/ARM/"/>
+    </repository>
     <!-- X86_64 -->
-    <!--    <repository type="rpm-md" alias="Kernel_HEAD" imageinclude="true"-->
-    <!--                profiles="Leap15.3.x86_64">-->
-    <!--        <source path="https://download.opensuse.org/repositories/Kernel:/HEAD/standard/"/>-->
-    <!--    </repository>-->
+    <repository type="rpm-md" alias="Kernel_HEAD" imageinclude="true"
+                profiles="Leap15.3.x86_64">
+        <source path="https://download.opensuse.org/repositories/Kernel:/HEAD/standard/"/>
+    </repository>
     <!-- Kernel Stable Backports -->
     <!-- https://build.opensuse.org/project/show/Kernel:stable:Backport -->
     <!-- Multi arch  -->
-    <repository type="rpm-md" alias="Kernel_stable_Backport" imageinclude="true"
-                profiles="Leap15.3.x86_64,Leap15.3.RaspberryPi4,Leap15.3.ARM64EFI">
-        <source path="https://download.opensuse.org/repositories/Kernel:/stable:/Backport/standard/"/>
-    </repository>
+    <!--    <repository type="rpm-md" alias="Kernel_stable_Backport" imageinclude="true"-->
+    <!--                profiles="Leap15.3.x86_64,Leap15.3.RaspberryPi4,Leap15.3.ARM64EFI">-->
+    <!--        <source path="https://download.opensuse.org/repositories/Kernel:/stable:/Backport/standard/"/>-->
+    <!--    </repository>-->
     <!-- btrfs-progs backport via filesystems repo -->
     <!-- https://build.opensuse.org/project/show/filesystems -->
     <repository type="rpm-md" alias="filesystems" imageinclude="true"

--- a/rockstor.kiwi
+++ b/rockstor.kiwi
@@ -394,13 +394,8 @@ which includes aarch64 relevant content -->
     <!-- btrfs-progs backport via filesystems repo -->
     <!-- https://build.opensuse.org/project/show/filesystems -->
     <repository type="rpm-md" alias="filesystems" imageinclude="true"
-                profiles="Leap15.3.x86_64">
+                profiles="Leap15.3.x86_64,Leap15.3.RaspberryPi4,Leap15.3.ARM64EFI">
         <source path="https://download.opensuse.org/repositories/filesystems/openSUSE_Leap_15.3/"/>
-    </repository>
-    <!-- the following arm repo for filesystems is untested -->
-    <repository type="rpm-md" alias="filesystems" imageinclude="true"
-                profiles="Leap15.3.RaspberryPi4,Leap15.3.ARM64EFI">
-        <source path="https://download.opensuse.org/repositories/filesystems/SLE_15_SP2/"/>
     </repository>
     <packages type="image">
         <package name="adaptec-firmware"/>  <!--Razor AIC94xx Series SAS-->

--- a/rockstor.kiwi
+++ b/rockstor.kiwi
@@ -378,19 +378,19 @@ which includes aarch64 relevant content -->
     <!-- "Installing a kernel from Kernel:HEAD should never be necessary, -->
     <!-- because important fixes are backported by SUSE and are made available as official updates. -->
     <!-- Installing the latest kernel only makes sense for kernel developers and kernel testers."-->
-    <!-- https://build.opensuse.org/repositories/Kernel:HEAD:Backport -->
     <!-- Kernel HEAD Backports -->
-    <repository type="rpm-md" alias="Kernel_HEAD_Backport" imageinclude="true"
-                profiles="Leap15.3.x86_64,Leap15.3.RaspberryPi4,Leap15.3.ARM64EFI">
-        <source path="https://download.opensuse.org/repositories/Kernel:/HEAD:/Backport/standard/"/>
-    </repository>
+    <!-- https://build.opensuse.org/repositories/Kernel:HEAD:Backport -->
+    <!--    <repository type="rpm-md" alias="Kernel_HEAD_Backport" imageinclude="true"-->
+    <!--                profiles="Leap15.3.x86_64,Leap15.3.RaspberryPi4,Leap15.3.ARM64EFI">-->
+    <!--        <source path="https://download.opensuse.org/repositories/Kernel:/HEAD:/Backport/standard/"/>-->
+    <!--    </repository>-->
     <!-- Kernel Stable Backports -->
     <!-- https://build.opensuse.org/project/show/Kernel:stable:Backport -->
     <!-- See also: https://rockstor.com/docs/howtos/stable_kernel_backport.html  -->
-    <!--    <repository type="rpm-md" alias="Kernel_stable_Backport" imageinclude="true"-->
-    <!--                profiles="Leap15.3.x86_64,Leap15.3.RaspberryPi4,Leap15.3.ARM64EFI">-->
-    <!--        <source path="https://download.opensuse.org/repositories/Kernel:/stable:/Backport/standard/"/>-->
-    <!--    </repository>-->
+    <repository type="rpm-md" alias="Kernel_stable_Backport" imageinclude="true"
+                profiles="Leap15.3.x86_64,Leap15.3.RaspberryPi4,Leap15.3.ARM64EFI">
+        <source path="https://download.opensuse.org/repositories/Kernel:/stable:/Backport/standard/"/>
+    </repository>
     <!-- btrfs-progs backport via filesystems repo -->
     <!-- https://build.opensuse.org/project/show/filesystems -->
     <repository type="rpm-md" alias="filesystems" imageinclude="true"


### PR DESCRIPTION
In some circumstances, mainly developmental, it is desirable to have an installer with a newer kernel than our upstream defaults. Provide remarked-out repositories appropriate for his.

Fixes #86
@FroggyFlox Draft pull request for now as using this pr to experiment and confirm intended function before removing draft flag after fully remarking out all these additional kernel & filesystem repositories.