### PR TITLE
Move rockstor package version to 4.1.0-0 #93

### DIFF
--- a/rockstor.kiwi
+++ b/rockstor.kiwi
@@ -497,8 +497,8 @@ which includes aarch64 relevant content -->
         <package name="systemtap-runtime"/>
         <package name="ypbind"/>
         <!--ROCKSTOR PACKAGE-->
-        <!--Change to reflect the version specified, i.e. 4.0.8-0-->
-        <package name="rockstor-4.0.8-0"/>
+        <!--Change to reflect the version specified, i.e. 4.1.0-0-->
+        <package name="rockstor-4.1.0-0"/>
     </packages>
     <packages type="image" profiles="Leap15.2.RaspberryPi4">
         <package name="raspberrypi-firmware" arch="aarch64"/>


### PR DESCRIPTION
As of HAL9000's birthday we now have a new rockstor package version which in turn fixes a few bugs we had in our Leap 15.3 profile.

Fixes #93 