### PR TITLE
Vagrant installation update: switching to buildbox approach

### DIFF
--- a/vagrant_env/README.md
+++ b/vagrant_env/README.md
@@ -5,14 +5,20 @@ specification.
 
 Pre-requisites
 -------------
-It is assumed that you have the following software packages installed on your host machine:
+The following software packages should be installed on the host machine:
 - Vagrant (https://www.vagrantup.com/downloads)
 - VirtualBox (https://www.virtualbox.org/wiki/Downloads)
 - Oracle VM VirtualBox Extension Pack (https://www.virtualbox.org/wiki/Downloads)
 
 Both packages/extensions are available on Linux, Mac OSX and Windows.
 
-It is also assumed that you have a local copy of this repository [rockstor-installer](https://github.com/rockstor/rockstor-installer) on your machine, see the top level README.md, and are currently within the 'vagrant_env' directory: where the Vagrantfile, build.sh, and run_kiwi.sh are.
+Also, a local copy of this repository [rockstor-installer](https://github.com/rockstor/rockstor-installer) on your machine, see the top level README.md, and are currently within the `vagrant_env` directory: where the `Vagrantfile`, `build.sh`, and `run_kiwi.sh` are located.
+
+A few notes on the processing flow:
+- Before bringing up the vagrant box, make adjustments to either of these files and also edit the `rockstor.kiwi` in the parent directory according to the options to be used (see top-level README.md).
+- Because the shared folder between the host and the VirtualBox VM cannot be accessed correctly by the KVM that the boxbuild generates, the 'run_kiwi.sh' file will be copied into the box from the host directory at the end of the vagrant box activation, so any changes should be done beforehand.
+- The `run_kiwi.sh` file in turn will then copy the `rockstor.kiwi` file into a fresh copy of the repository directly on the vagrant box, which is then accessible by the 'kiwi-ng' generated KVM.
+- At the end of the boxbuild process, the files in the resulting output directory will be copied back into the host directory, so they can then be used without having to be logged into the vagrant box. The final steps clean up the repository and the directory holding the iso file. This way a new build with other settings in `rockstor.kiwi` can be executed without having to recreate the vagrant box from scratch.
 
 Configuring Profiles
 --------------------
@@ -31,37 +37,38 @@ Vagrant Boxes for OpenSUSE Leap
 -------------------------------
 
 This vagrant file uses the vagrant boxes: 
-- [opensuse/leap-15.2.x86_64](https://app.vagrantup.com/opensuse/boxes/Leap-15.2.x86_64)
+- [opensuse/leap-15.3.x86_64](https://app.vagrantup.com/opensuse/boxes/Leap-15.3.x86_64) or
+- [opensuse/leap-15.3.aarch64](https://app.vagrantup.com/opensuse/boxes/Leap-15.3.aarch64)
 
-or
-- [opensuse/leap-15.2.aarch64](https://app.vagrantup.com/opensuse/boxes/Leap-15.2.aarch64)
-
-eg.
+which can be found in the `Vagrantfile` under this setting:
 ```
-v.vm.box = 'opensuse/Leap-15.2.x86_64' 
+v.vm.box = 'opensuse/Leap-15.3.x86_64' 
 ```
 
-These boxes for vagrant are based on official images with the virtualisation tools added.  
+These boxes for vagrant are based on official images with the virtualisation tools added.
+
+Note: in some instances when VirtualBox Guest Additions are not the same on the VirtualBox installation and the OpenSUSE image, problems can occur. In the Vagrantfile there is an option to edit (comment/uncomment) a bento based vagrant box of the LEAP OS, which has shown to work as well in a cinch.
 
 Building the Rockstor ISO installer
 -----------------------------------
+As indicated in the top-level readme, make adjustments to the 'rockstor.kiwi' in the top-level directory (e.g. `rockstor-installer`) before returning to the `vagrant-env` directory and initiate the rockstor ISO build.
+
 On Mac OSX, Linux and Windows with Bash installed, execute the build script:
 
 ```shell script
 ./build.sh
 ```
-
-On Windows without Bash installed, executed:
+On Windows without Bash installed, execute:
 
 ```
 vagrant up
-vagrant ssh -c "cd /home/vagrant/rockstor-installer/vagrant_env; ./run_kiwi.sh"
+vagrant ssh -c "./run_kiwi.sh"
 ```
 
 This will build and provision the vagrant box. It will then run kiwi in the virtual machine to build the Rockstor 
 Installer ISO.
 
-The resultant ISO will be available in this directory. (eg. ./rockstor-installer/vagrant_env)
+The resultant ISO will be available in this directory. (e.g., ./rockstor-installer/kiwi-images)
 
 Managing the Virtual Machine
 ----------------------------

--- a/vagrant_env/Vagrantfile
+++ b/vagrant_env/Vagrantfile
@@ -11,8 +11,13 @@ required_plugins.each do |plugin|
   system "vagrant plugin install #{plugin}" unless Vagrant.has_plugin? plugin
 end
 
-MEM = 2048
-CPU = 2
+# !!! IMPORTANT !!!
+# If host machine has sufficient memory and CPUs use these values, otherwise reduce accordingly to not cripple the host machine.
+# If adjusting here, ensure that the command line to start the installer build is adjusted for memory and CPUs as well.
+MEM = 8192
+CPU = 4
+
+# Environment Profiles - currently only 
 PROFILE = ENV['PROFILE'] || 'x86_64'
 
 VAGRANTFILE_API_VERSION = '2'
@@ -21,55 +26,48 @@ VAGRANTFILE_API_VERSION = '2'
 #  in the wiki:  https://github.com/josenk/vagrant-vmware-esxi/wiki
 Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
 
+	# map external folders
     config.vm.synced_folder "./", "/vagrant"
     config.vm.synced_folder "../", "/home/vagrant/rockstor-installer"
 
-    # Disable update of guest additions when box is opensuse
-    # Comment out until we get back to opensuse
-    #if vagrant.has_plugin?("vagrant-vbguest")
-    #  config.vbguest.auto_update = false
-    #end
-
-    config.vm.define "rockstor-installer" do |v|
+     config.vm.define "rockstor-installer" do |v|
         v.vm.hostname = "rockstor-installer"
         if PROFILE == "x86_64" then
-            # Switch back to bento until we figure out what broke in opensuse
-            #v.vm.box = 'opensuse/Leap-15.2.x86_64'
-            #v.vm.box_version = "15.2.31.325"
-            v.vm.box = 'bento/opensuse-leap-15'
+            # One can switch back to bento in case OpenSUSE is broken (typically issues around VB guest additions
+            v.vm.box = 'opensuse/Leap-15.3.x86_64'
+		# if a specific version should be used:
+			# v.vm.box_version = '15.3.9.361'
+            # v.vm.box = 'bento/opensuse-leap-15.3'
+		# if a specific version should be used:
+			# v.vm.box_version = '202112.23.0'
         else
-            v.vm.box = 'opensuse/Leap-15.2.aarch64'
+            v.vm.box = 'opensuse/Leap-15.3.aarch64'
         end
 
-        # Provider specific variable
+        # Provider specific variables
         v.vm.provider :virtualbox do |vb|
             vb.memory = MEM
             vb.cpus = CPU
+			# Enable nested VMs, so kiwi box-build can be used
+			vb.customize ['modifyvm', :id, '--nested-hw-virt', 'on']
         end
 
         if PROFILE == "x86_64" then
             config.vm.provision "shell", inline: <<-SHELL
-                sudo zypper --non-interactive addrepo --refresh http://download.opensuse.org/repositories/Virtualization:/Appliances:/Builder/openSUSE_Leap_15.2/ appliance-builder
-                sudo zypper --non-interactive --gpg-auto-import-keys refresh
-            SHELL
-        else
-            config.vm.provision "shell", inline: <<-SHELL
-                sudo zypper --non-interactive addrepo --refresh http://download.opensuse.org/repositories/Virtualization:/Appliances:/Builder/openSUSE_Leap_15.2_ARM/ appliance-builder
-                sudo zypper --non-interactive --gpg-auto-import-keys refresh
-            SHELL
-        end
-
-        config.vm.provision "shell", inline: <<-SHELL
-            REPO_URL="https://github.com/rockstor/rockstor-installer.git"
-            REPO_DIR="rockstor-installer/"
-            sudo zypper --non-interactive install git btrfsprogs gfxboot
-            sudo zypper --non-interactive install python3-kiwi
-            if [ ! -e ${REPO_DIR} ]; then
-                git clone ${REPO_URL} ${REPO_DIR}
-            fi
-            # Fix for broken python lxml (see: https://www.suse.com/support/kb/doc/?id=000019818)
-            pip install --force-reinstall lxml
+			# install KVM and KVM tools for virtual machine within VM & python dev tools
+				sudo zypper -n install -t pattern kvm_server kvm_tools
+				sudo zypper -n install git python3-devel gcc
+			# create virtual python environment
+				python3 -m venv kiwi-env
+			# update pip if necessary
+				sudo ./kiwi-env/bin/python3 -m pip install --upgrade pip
+			# install kiwi and kiwi box plugin
+				./kiwi-env/bin/pip3 install kiwi kiwi-boxed-plugin
+			# copy build script from local to VM
+				sudo cp ./rockstor-installer/vagrant_env/run_kiwi.sh ./
+			# make build script executable
+				sudo chmod u+x run_kiwi.sh
         SHELL
+		end
     end
 end
-

--- a/vagrant_env/run_kiwi.sh
+++ b/vagrant_env/run_kiwi.sh
@@ -1,23 +1,63 @@
 #!/bin/bash
+# Bash parameters
 set -e
 set -u
 #set -x
 
-PROFILE=${1:-x86_64}
-#PROFILE="RaspberryPi4"
+# Processing Profile Parameters
+PROFILE="Leap15.3.x86_64"
 
-KIWI_BUILD_DIR="/home/vagrant/kiwi-images/"
-REPO_DIR="/home/vagrant/rockstor-installer/"
+# Memory and CPUs need to be less than stipulated in the Vagrantfile
+MEM="6G"
+CPU="3"
+
+# Set Path Variables
+HOME_PATH="/home/vagrant"
+REPO_SOURCE_PATH="/home/vagrant/rockstor-installer"
+REPO_PATH="/home/vagrant/repo"
+REPO_URL="https://github.com/rockstor/rockstor-installer.git"
+KIWI_NG_PATH="/home/vagrant/kiwi-env/bin"
+KIWI_IMAGES="/home/vagrant/kiwi-images/"
+DESCRIPTION="./"
 
 echo '============================================='
 echo 'Starting Build'
 echo '============================================='
-cd ${REPO_DIR}
-if [ -e ${KIWI_BUILD_DIR} ]; then
-    sudo rm -rf "${KIWI_BUILD_DIR}/build";
+echo 'Get most recent git into Vagrant Box'
+echo '============================================='
+
+if [ ! -e ${REPO_PATH} ]; then
+	sudo git clone ${REPO_URL} ${REPO_PATH}
 fi
-sudo kiwi-ng --profile=Leap15.2."${PROFILE}" --type oem system build --description ./ --target-dir "${KIWI_BUILD_DIR}/"
-sudo find ${KIWI_BUILD_DIR} -name "*.iso" -exec cp {} /vagrant/ \;
+
+echo '============================================='
+echo 'insert rockstor.kiwi from local directory'
+echo '============================================='
+# force copy to have the latest version inside the vagrant box
+sudo cp -fv "$REPO_SOURCE_PATH"/rockstor.kiwi "$REPO_PATH"/rockstor.kiwi
+
+echo '============================================='
+echo 'executing kiwi-ng'
+echo '============================================='
+# change into repo directory before executing kiwi-ng
+cd "$REPO_PATH"
+sudo "$KIWI_NG_PATH"/kiwi-ng --profile="$PROFILE" --type oem system boxbuild --box-memory "$MEM" --box-smp-cpus="$CPU" --box leap -- --description "$DESCRIPTION" --target-dir "$KIWI_IMAGES"
+
+echo '============================================='
+echo 'Copying image directory to local'
+echo '============================================='
+# force copy to outside of vagrant box
+sudo cp -fRv "$KIWI_IMAGES" "$REPO_SOURCE_PATH"
+
+echo '============================================='
+echo 'Clean up kiwi-images and git repo'
+echo '============================================='
+cd "$HOME_PATH"
+sudo rm -rf "$KIWI_IMAGES"
+sudo rm -rf "$REPO_PATH"
 echo '============================================='
 echo 'Finished Build'
+echo '============================================='
+echo 'Status and result logs can be found in "$REPO_SOURCE_PATH" directory'
+echo 'Auf Wiedersehen'
 echo '============================================='


### PR DESCRIPTION
Fixes #104.
Switching to kiwi-ng boxbuild approach to reduce dependency on host vagrant box.
Updates to run-kiwi.sh, vagrantfile, and readme.md in the vagrant_env directory.

Still only working for the x86_64 profile, as I have not had the opportunity to test the other architectures