### PR TITLE
Correct unedited-default version number #109

### DIFF
--- a/rockstor.kiwi
+++ b/rockstor.kiwi
@@ -50,7 +50,7 @@ which includes aarch64 relevant content -->
     </profiles>
     <preferences profiles="Leap15.2.x86_64,Leap15.3.x86_64,Tumbleweed.x86_64">
         <!--Change to reflect the Rockstor version used #.#.# (rpm version) -# (rpm release)-->
-        <version>4.0.8-0</version>
+        <version>4.1.0-0</version>
         <packagemanager>zypper</packagemanager>
         <locale>en_GB</locale>
         <keytable>gb</keytable>
@@ -105,7 +105,7 @@ which includes aarch64 relevant content -->
 
     <preferences profiles="Leap15.2.RaspberryPi4,Leap15.3.RaspberryPi4">
         <!--Change to reflect the Rockstor version used #.#.# (rpm version) -# (rpm release)-->
-        <version>4.0.8-0</version>
+        <version>4.1.0-0</version>
         <packagemanager>zypper</packagemanager>
         <locale>en_GB</locale>
         <keytable>gb</keytable>
@@ -156,7 +156,7 @@ which includes aarch64 relevant content -->
     </preferences>
     <preferences profiles="Leap15.2.ARM64EFI,Leap15.3.ARM64EFI">
         <!--Change to reflect the Rockstor version used #.#.# (rpm version) -# (rpm release)-->
-        <version>4.0.8-0</version>
+        <version>4.1.0-0</version>
         <packagemanager>zypper</packagemanager>
         <locale>en_GB</locale>
         <keytable>gb</keytable>


### PR DESCRIPTION
Now reflects, as comments suggest, the stated current rockstor package version. Assists with consistency in build where no config edits are made.

Follow up to prior, and incomplete, rockstor package version edit from 4.0.8-0 to 4.1.0-0.
See: "Move rockstor package version to 4.1.0-0" #93 #94

Default, no-edited builds will now provide appropriately versioning, consistent with the included rockstor rpm version.