### PR TITLE
Add infiniband capability #90

### DIFF
--- a/rockstor.kiwi
+++ b/rockstor.kiwi
@@ -426,6 +426,7 @@ which includes aarch64 relevant content -->
         <package name="grub2-snapper-plugin"/>
         <package name="grub2-x86_64-efi" arch="x86_64"/>
         <package name="htop"/>
+        <package name="ibutils"/> <!-- OpenIB Mellanox InfiniBand Diagnostic Tools -->
         <package name="iproute2"/>
         <package name="iputils"/>
         <package name="jeos-firstboot"/>


### PR DESCRIPTION
Provide diagnostic tools within installer to address potential chicken/egg scenarios regarding network issues on infiniband only systems.

Size cost around 18 MiB.

Fixes #90 

## Caveat
From: https://software.opensuse.org/package/ibutils
We do not yet see a Leap 15.4 package available. However we do not yet have a Leap 15.4 profile.
If this package is still not available upon our 15.4 profile emerging we should confine to 15.3 profiles.