### PR TITLE
add remarked out open-vm-tools package entry #95

### DIFF
--- a/rockstor.kiwi
+++ b/rockstor.kiwi
@@ -439,6 +439,7 @@ which includes aarch64 relevant content -->
         <package name="NetworkManager-branding-upstream"/>  <!--or branding-openSUSE-->
         <package name="nfs-client"/>
         <package name="open-iscsi"/>
+        <!-- <package name="open-vm-tools"/> -->
         <package name="openssh"/>
         <package name="parted"/>
         <package name="patterns-base-base"/>


### PR DESCRIPTION
More easily facilitate this packages addition for those managing their own custom installer config.
Size cost, if introduced, approximately 6 MiB

Fixes #95 