### PR TITLE
Remove Leap 15.2 profiles #91

### DIFF
--- a/_multibuild
+++ b/_multibuild
@@ -1,4 +1,4 @@
 <multibuild>
-  <flavor>Leap15.2.x86_64</flavor>
-  <flavor>Leap15.2.RaspberryPi4</flavor>
+  <flavor>Leap15.3.x86_64</flavor>
+  <flavor>Leap15.3.RaspberryPi4</flavor>
 </multibuild>

--- a/config.sh
+++ b/config.sh
@@ -162,7 +162,7 @@ sed -i 's/https:\/\/www.opensuse.org/http:\/\/rockstor.com/g' /usr/lib/os-releas
 # Configure Raspberry Pi specifics
 # from: https://build.opensuse.org/package/view_file/openSUSE:Factory:ToTest/kiwi-templates-JeOS/config.sh
 #--------------------------------------
-if [[ "$kiwi_profiles" == *"Leap15.2.RaspberryPi4"* ]] || [[ "$kiwi_profiles" == *"Leap15.3.RaspberryPi4"* ]]; then
+if [[ "$kiwi_profiles" == *"Leap15.3.RaspberryPi4"* ]]; then
   # Also show WLAN interfaces in /etc/issue
   baseUpdateSysConfig /etc/sysconfig/issue-generator NETWORK_INTERFACE_REGEX '^[bew]'
 

--- a/rockstor.kiwi
+++ b/rockstor.kiwi
@@ -2,15 +2,14 @@
 <!-- schema doc available at:
 https://osinside.github.io/kiwi/development/schema.html#schema-docs -->
 <!-- For reference we have:
-https://build.opensuse.org/project/show/Virtualization:Appliances:Images:openSUSE-Leap-15.2
-https://build.opensuse.org/package/view_file/Virtualization:Appliances:Images:openSUSE-Leap-15.2/kiwi-templates-JeOS/JeOS.kiwi
-https://build.opensuse.org/project/show/Virtualization:Appliances:Images:openSUSE-Tumbleweed
-And of specific Pi4 interest:
-https://build.opensuse.org/package/view_file/openSUSE:Leap:15.2:ARM:Images/JeOS/JeOS-raspberrypi4.aarch64.kiwi
-which includes aarch64 relevant content -->
+https://en.opensuse.org/Portal:JeOS
+https://documentation.suse.com/kiwi/9/single-html/kiwi/index.html
+https://build.opensuse.org/package/show/openSUSE:Leap:15.3/kiwi-templates-JeOS
+https://build.opensuse.org/package/show/openSUSE:Leap:15.3:Images/JeOS
+-->
 <!-- OBS-Profiles: @BUILD_FLAVOR@ -->
 
-<!--Change to "Rockstor-<baseos-machine>" e.g. "Rockstor-Leap15.2-RaspberryPi4"-->
+<!--Change to "Rockstor-<baseos-machine>" e.g. "Rockstor-Leap15.3-RaspberryPi4"-->
 <image schemaversion="7.1" name="Rockstor-NAS">
 
     <description type="system">
@@ -24,15 +23,6 @@ which includes aarch64 relevant content -->
         <!-- For preferences, drivers, repository, packages, and users elements -->
         <!-- https://osinside.github.io/kiwi/working_with_kiwi/xml_description.html#image-profiles-->
         <!-- N.B. can inherit one profile within another via requires profile="" -->
-        <profile name="Leap15.2.x86_64"
-                 description="Rockstor built on openSUSE Leap 15.2 x86_64"
-                 arch="x86_64"/>
-        <profile name="Leap15.2.RaspberryPi4"
-                 description="Rockstor built on openSUSE Leap 15.2 Raspberry_Pi"
-                 arch="aarch64"/>
-        <profile name="Leap15.2.ARM64EFI"
-                         description="Rockstor built on openSUSE Leap 15.2 ARM64 EFI/VM/Ten64"
-                         arch="aarch64"/>
         <profile name="Leap15.3.x86_64"
                  description="Rockstor built on openSUSE Leap 15.3 x86_64"
                  arch="x86_64"/>
@@ -48,7 +38,7 @@ which includes aarch64 relevant content -->
                  description="Rockstor built on openSUSE Tumbleweed x86_64"
                  arch="x86_64"/>
     </profiles>
-    <preferences profiles="Leap15.2.x86_64,Leap15.3.x86_64,Tumbleweed.x86_64">
+    <preferences profiles="Leap15.3.x86_64,Tumbleweed.x86_64">
         <!--Change to reflect the Rockstor version used #.#.# (rpm version) -# (rpm release)-->
         <version>4.1.0-0</version>
         <packagemanager>zypper</packagemanager>
@@ -103,7 +93,7 @@ which includes aarch64 relevant content -->
         </type>
     </preferences>
 
-    <preferences profiles="Leap15.2.RaspberryPi4,Leap15.3.RaspberryPi4">
+    <preferences profiles="Leap15.3.RaspberryPi4">
         <!--Change to reflect the Rockstor version used #.#.# (rpm version) -# (rpm release)-->
         <version>4.1.0-0</version>
         <packagemanager>zypper</packagemanager>
@@ -154,7 +144,7 @@ which includes aarch64 relevant content -->
             </oemconfig>
         </type>
     </preferences>
-    <preferences profiles="Leap15.2.ARM64EFI,Leap15.3.ARM64EFI">
+    <preferences profiles="Leap15.3.ARM64EFI">
         <!--Change to reflect the Rockstor version used #.#.# (rpm version) -# (rpm release)-->
         <version>4.1.0-0</version>
         <packagemanager>zypper</packagemanager>
@@ -218,18 +208,10 @@ which includes aarch64 relevant content -->
     </users>
     <!-- For zypper priority 1 is highest, priority 0 returns to default of 99 -->
     <!-- https://build.opensuse.org/project/show/Virtualization:Appliances:Builder -->
-    <repository type="rpm-md" alias="kiwi" priority="1"
-                profiles="Leap15.2.x86_64">
-        <source path="obs://Virtualization:Appliances:Builder/openSUSE_Leap_15.2"/>
-    </repository>
     <!-- Leap 15.3 repo now dual architecture -->
     <repository type="rpm-md" alias="kiwi" priority="1"
                 profiles="Leap15.3.x86_64,Leap15.3.RaspberryPi4,Leap15.3.ARM64EFI">
         <source path="obs://Virtualization:Appliances:Builder/openSUSE_Leap_15.3"/>
-    </repository>
-    <repository type="rpm-md" alias="kiwi" priority="1"
-                profiles="Leap15.2.RaspberryPi4,Leap15.2.ARM64EFI">
-        <source path="obs://Virtualization:Appliances:Builder/openSUSE_Leap_15.2_ARM"/>
     </repository>
     <repository type="rpm-md" alias="kiwi" priority="1"
                 profiles="Tumbleweed.x86_64">
@@ -237,14 +219,6 @@ which includes aarch64 relevant content -->
     </repository>
     <!-- https://en.opensuse.org/Package_repositories -->
     <!-- Alias repo-oss Name="Main Repository" in JeOS-->
-    <repository type="rpm-md" alias="Leap_15_2" imageinclude="true"
-                profiles="Leap15.2.x86_64">
-        <source path="obs://openSUSE:Leap:15.2/standard"/>
-    </repository>
-    <repository type="rpm-md" alias="Leap_15_2" imageinclude="true"
-                profiles="Leap15.2.RaspberryPi4,Leap15.2.ARM64EFI">
-        <source path="https://download.opensuse.org/ports/aarch64/distribution/leap/15.2/repo/oss/"/>
-    </repository>
     <!-- Leap 15.3 repo now multi architecture -->
     <repository type="rpm-md" alias="Leap_15_3" imageinclude="true"
                 profiles="Leap15.3.x86_64,Leap15.3.RaspberryPi4,Leap15.3.ARM64EFI">
@@ -255,14 +229,6 @@ which includes aarch64 relevant content -->
         <source path="obs://openSUSE:Tumbleweed/standard"/>
     </repository>
     <!-- Alias repo-update Name="Main Update Repository" or "openSUSE-Tumbleweed-Update" in JeOS-->
-    <repository type="rpm-md" alias="Leap_15_2_Updates" imageinclude="true"
-                profiles="Leap15.2.x86_64">
-        <source path="https://download.opensuse.org/update/leap/15.2/oss/"/>
-    </repository>
-    <repository type="rpm-md" alias="Leap_15_2_Updates" imageinclude="true"
-                profiles="Leap15.2.RaspberryPi4,Leap15.2.ARM64EFI">
-        <source path="https://download.opensuse.org/ports/update/leap/15.2/oss/"/>
-    </repository>
     <!-- Leap 15.3 repo now multi architecture -->
     <repository type="rpm-md" alias="Leap_15_3_Updates" imageinclude="true"
                 profiles="Leap15.3.x86_64,Leap15.3.RaspberryPi4,Leap15.3.ARM64EFI">
@@ -295,14 +261,6 @@ which includes aarch64 relevant content -->
     <!--    </repository>-->
     <!-- Resource Rockstor Testing channel during installer build only -->
     <repository type="rpm-md" alias="Rockstor-Testing"
-                profiles="Leap15.2.x86_64">
-        <source path="http://updates.rockstor.com:8999/rockstor-testing/leap/15.2/"/>
-    </repository>
-    <repository type="rpm-md" alias="Rockstor-Testing"
-                profiles="Leap15.2.RaspberryPi4,Leap15.2.ARM64EFI">
-        <source path="http://updates.rockstor.com:8999/rockstor-testing/leap/15.2_aarch64/"/>
-    </repository>
-    <repository type="rpm-md" alias="Rockstor-Testing"
                 profiles="Leap15.3.x86_64">
         <source path="http://updates.rockstor.com:8999/rockstor-testing/leap/15.3/"/>
     </repository>
@@ -318,16 +276,6 @@ which includes aarch64 relevant content -->
     <!-- https://build.opensuse.org/package/show/shells/shellinabox -->
     <!-- Lower priority (higher number) than default 99 to avoid other dev shell packages supplanting -->
     <!-- those in default repositories. Shellinabox is not currently offered as part of the base system -->
-    <repository type="rpm-md" alias="shells" priority="105" imageinclude="true"
-                profiles="Leap15.2.x86_64">
-        <source path="https://download.opensuse.org/repositories/shells/openSUSE_Leap_15.2/"/>
-    </repository>
-    <!-- TODO: NOT YET AVAILABLE FOR LEAP 15.2 ON aarch64 so using mcbridematt repo for now -->
-    <!-- Previously shells/openSUSE_Factory_ARM worked but glibc updates there now prevent this -->
-    <!--    <repository type="rpm-md" alias="shells" priority="105" imageinclude="true"-->
-    <!--                profiles="Leap15.2.RaspberryPi4,Leap15.2.ARM64EFI">-->
-    <!--        <source path="https://download.opensuse.org/repositories/shells/openSUSE_Factory_ARM/"/>-->
-    <!--    </repository>-->
     <!-- Rockstor home repo on OBS for Leap 15.3 + now hosts dual arch shellinabox -->
     <!-- Maintain lower priority to upstream in case shellinabox is added there -->
     <!-- https://build.opensuse.org/project/show/home:rockstor -->
@@ -343,14 +291,6 @@ which includes aarch64 relevant content -->
     <!-- We are required to de/re-brand packages that have no "...branding-upstream" equivalent-->
     <!-- This repo currently provides: systemd-presets-branding-rockstor -->
     <!-- https://build.opensuse.org/package/show/home:rockstor:branches:Base:System/systemd-presets-branding-rockstor -->
-    <repository type="rpm-md" alias="home_rockstor_branches_Base_System" priority="97" imageinclude="true"
-                profiles="Leap15.2.x86_64">
-        <source path="https://download.opensuse.org/repositories/home:/rockstor:/branches:/Base:/System/openSUSE_Leap_15.2/"/>
-    </repository>
-    <repository type="rpm-md" alias="home_rockstor_branches_Base_System" priority="97" imageinclude="true"
-                profiles="Leap15.2.RaspberryPi4,Leap15.2.ARM64EFI">
-        <source path="https://download.opensuse.org/repositories/home:/rockstor:/branches:/Base:/System/openSUSE_Leap_15.2_ARM/"/>
-    </repository>
     <!-- Leap 15.3 repo now multi architecture -->
     <repository type="rpm-md" alias="home_rockstor_branches_Base_System" priority="97" imageinclude="true"
                 profiles="Leap15.3.x86_64,Leap15.3.RaspberryPi4,Leap15.3.ARM64EFI">
@@ -361,13 +301,8 @@ which includes aarch64 relevant content -->
                 profiles="Tumbleweed.x86_64">
         <source path="https://download.opensuse.org/repositories/home:/rockstor:/branches:/Base:/System/openSUSE_Factory/"/>
     </repository>
-    <!-- For Traverse Ten64 drivers and aarch64 shellinabox (while no aarch64 shells repo exists) -->
+    <!-- For Traverse Ten64 drivers -->
     <!-- https://build.opensuse.org/project/show/home:mcbridematt  -->
-    <repository type="rpm-md" alias="mcbridematt" imageinclude="true"
-                profiles="Leap15.2.ARM64EFI,Leap15.2.RaspberryPi4,">
-        <source path="obs://home:mcbridematt/openSUSE_Leap_15.2/" />
-    </repository>
-    <!-- As of Leap 15.3 home_rockstor hosts multi-arch shellinabox -->
     <repository type="rpm-md" alias="mcbridematt" imageinclude="true"
                 profiles="Leap15.3.ARM64EFI">
         <source path="obs://home:mcbridematt/openSUSE_Leap_15.3/" />
@@ -505,14 +440,6 @@ which includes aarch64 relevant content -->
         <!--Change to reflect the version specified, i.e. 4.1.0-0-->
         <package name="rockstor-4.1.0-0"/>
     </packages>
-    <packages type="image" profiles="Leap15.2.RaspberryPi4">
-        <package name="raspberrypi-firmware" arch="aarch64"/>
-        <package name="raspberrypi-firmware-config" arch="aarch64"/>
-        <package name="raspberrypi-firmware-dt" arch="aarch64"/>
-        <!-- For WiFi: -->
-        <package name="bcm43xx-firmware"/>
-        <package name="u-boot-rpiarm64" arch="aarch64"/>
-    </packages>
     <packages type="image" profiles="Leap15.3.RaspberryPi4">
         <package name="raspberrypi-eeprom" arch="aarch64"/>
         <package name="raspberrypi-firmware" arch="aarch64"/>
@@ -521,15 +448,6 @@ which includes aarch64 relevant content -->
         <!-- For WiFi: -->
         <package name="bcm43xx-firmware"/>
         <package name="u-boot-rpiarm64" arch="aarch64"/>
-    </packages>
-    <packages type="image" profiles="Leap15.2.ARM64EFI">
-        <!-- Support for Traverse Ten64 features -->
-        <package name="traverse-board-support" arch="aarch64"/>
-        <!-- without -default kiwi-ng might try to resolve another kernel variant -->
-        <package name="traverse-sensors-kmp-default" arch="aarch64"/>
-        <package name="traverse-sensors" arch="aarch64"/>
-        <package name="gpio-mpc8xxx-kmp-default" arch="aarch64"/>
-        <package name="gpio-mpc8xxx" arch="aarch64"/>
     </packages>
     <!--    <packages type="oem" profiles="x86_64,Ten64">-->
     <!--    </packages>-->


### PR DESCRIPTION
Having already removed reference to our now EOL 15.2 based profiles from our Readme we can now remove the profile
config reverences themselves. This assists with ongoing maintenance and aids folks trying to do their own custom configs.

Fixes #91 

## Includes
- Updated references for the JeOS concept and Kiwi-ng.
- config.sh and _multibuild updates re profiles.