### PR TITLE
Add nomodeset to our default x86_64 kernel options #100

### DIFF
--- a/rockstor.kiwi
+++ b/rockstor.kiwi
@@ -64,7 +64,7 @@ https://build.opensuse.org/package/show/openSUSE:Leap:15.3:Images/JeOS
                 bootloader="grub2"
                 firmware="efi"
                 installiso="true"
-                kernelcmdline="plymouth.enable=0 rd.kiwi.oem.maxdisk=5000G"
+                kernelcmdline="nomodeset plymouth.enable=0 rd.kiwi.oem.maxdisk=5000G"
                 bootpartition="false"
                 devicepersistency="by-label"
                 btrfs_root_is_snapshot="true"


### PR DESCRIPTION
With some AMD hardware this can prevent a display failure for the installer. On some newer systems this can result in a failure to use newer/higher res text modes but the change was considered important enough for the show-stopper instances to add regardless.

Fixes #100 