### PR TITLE
add bnx2 network adapter firmware #108

### DIFF
--- a/rockstor.kiwi
+++ b/rockstor.kiwi
@@ -366,6 +366,7 @@ https://build.opensuse.org/package/show/openSUSE:Leap:15.3:Images/JeOS
         <package name="iputils"/>
         <package name="jeos-firstboot"/>
         <package name="kernel-default"/>
+        <package name="kernel-firmware-bnx2"/>
         <package name="keyutils"/>
         <package name="less"/>
         <package name="lsof"/>  <!--for zypper ps-->


### PR DESCRIPTION
Enable bnx2 network adapter via kernel firmware package inclusion.

Thanks to @BeardedTek for driving this one via the following issue:

Fixes #108 