### PR TITLE
revert to 'suseInsertService chronyd' #54

### DIFF
--- a/config.sh
+++ b/config.sh
@@ -110,13 +110,7 @@ fi
 # Enable chrony if installed
 #-------------------------------------
 if [ -f /etc/chrony.conf ]; then
-  # chronyc sits at 100% CPU even if chronyd service is disable
-  # Looks like: https://github.com/balena-os/meta-balena/issues/1360
-  # This should help once sorted; for now not installing chronyd (shame)
-  # suseInsertService chronyd
-  for i in 0 1 2 3; do
-    echo "server $i.opensuse.pool.ntp.org iburst"
-  done > /etc/chrony.d/opensuse.conf
+    suseInsertService chronyd
 fi
 
 #=====================================


### PR DESCRIPTION
Update our chronyd config via Kiwi-ng build-in. This brings us closer to our JeOS Leap 15.3 Appliance upstream. Dropping our prior my-hand additional server configs.

Fixes #54 