### PR TITLE
Add nmtui & nmcli prompt to 'myip' output when no IP address found #96

### DIFF
--- a/root/root/bin/myip
+++ b/root/root/bin/myip
@@ -5,6 +5,6 @@ if [[ $MYIP ]]
 then
     echo $MYIP
 else
-    echo "No DHCP assigned IP address found."
+    echo "No DHCP-assigned IP address found."
     echo "Use 'nmtui' or 'nmcli' to set a static IP address."
 fi

--- a/root/root/bin/myip
+++ b/root/root/bin/myip
@@ -1,3 +1,10 @@
 #!/bin/bash
-# Quick hack to get ip address, change to wrapper around python script.
-ip a | grep -oE '((1?[0-9][0-9]?|2[0-4][0-9]|25[0-5])\.){3}(1?[0-9][0-9]?|2[0-4][0-9]|25[0-5])' | grep -v '127\|255' | sed -e "s/^/https:\/\//"
+# Quick hack to get ip address.
+MYIP=$(ip a | grep -oE '((1?[0-9][0-9]?|2[0-4][0-9]|25[0-5])\.){3}(1?[0-9][0-9]?|2[0-4][0-9]|25[0-5])' | grep -v '127\|255' | sed -e "s/^/https:\/\//")
+if [[ $MYIP ]]
+then
+    echo $MYIP
+else
+    echo "No DHCP assigned IP address found."
+    echo "Use 'nmtui' or 'nmcli' to set a static IP address."
+fi


### PR DESCRIPTION
Usability enhancement to prompt folks to use NetworkManager command line tools when our 'myip' helper finds no IP address.

Fixes #96 
Ready for review.

## Testing
Edited a local installer instance of myip as per proposed change and tested as per issue text:

![myip-noip-fix](https://user-images.githubusercontent.com/2521585/185762273-70ff1397-39f7-44d8-945e-8f3b1eef1a9d.png)

