### PR TITLE
Add Leap 15.4 profiles #123

### DIFF
--- a/rockstor.kiwi
+++ b/rockstor.kiwi
@@ -32,15 +32,30 @@ https://build.opensuse.org/package/show/openSUSE:Leap:15.3:Images/JeOS
         <profile name="Leap15.3.ARM64EFI"
                  description="Rockstor built on openSUSE Leap 15.3 ARM64 EFI/VM/Ten64"
                  arch="aarch64"/>
-        <!-- Tumbleweed.x86_64 profile currently broken due to now missing python2 dependencies -->
-        <!-- maintaining for use testing Python 3 migration within testing channel -->
+        <profile name="Leap15.4.x86_64"
+                 description="Rockstor built on openSUSE Leap 15.4 x86_64"
+                 arch="x86_64"/>
+        <profile name="Leap15.4.RaspberryPi4"
+                 description="Rockstor built on openSUSE Leap 15.4 Raspberry_Pi"
+                 arch="aarch64"/>
+        <profile name="Leap15.4.ARM64EFI"
+                 description="Rockstor built on openSUSE Leap 15.4 ARM64 EFI/VM/Ten64"
+                 arch="aarch64"/>
+        <!-- Tumbleweed.x86_64 profiles in development -->
+        <!-- for testing Python 3 migration within testing channel -->
         <profile name="Tumbleweed.x86_64"
                  description="Rockstor built on openSUSE Tumbleweed x86_64"
                  arch="x86_64"/>
+        <profile name="Tumbleweed.RaspberryPi4"
+                 description="Rockstor built on openSUSE Tumbleweed x86_64"
+                 arch="aarch64"/>
+        <profile name="Tumbleweed.ARM64EFI"
+                 description="Rockstor built on openSUSE Tumbleweed ARM64 EFI/VM/Ten64"
+                 arch="aarch64"/>
     </profiles>
-    <preferences profiles="Leap15.3.x86_64,Tumbleweed.x86_64">
+    <preferences profiles="Leap15.3.x86_64,Leap15.4.x86_64,Tumbleweed.x86_64">
         <!--Change to reflect the Rockstor version used #.#.# (rpm version) -# (rpm release)-->
-        <version>4.1.0-0</version>
+        <version>4.5.4-0</version>
         <packagemanager>zypper</packagemanager>
         <locale>en_GB</locale>
         <keytable>gb</keytable>
@@ -93,9 +108,9 @@ https://build.opensuse.org/package/show/openSUSE:Leap:15.3:Images/JeOS
         </type>
     </preferences>
 
-    <preferences profiles="Leap15.3.RaspberryPi4">
+    <preferences profiles="Leap15.3.RaspberryPi4,Leap15.4.RaspberryPi4,Tumbleweed.RaspberryPi4">
         <!--Change to reflect the Rockstor version used #.#.# (rpm version) -# (rpm release)-->
-        <version>4.1.0-0</version>
+        <version>4.5.4-0</version>
         <packagemanager>zypper</packagemanager>
         <locale>en_GB</locale>
         <keytable>gb</keytable>
@@ -144,9 +159,9 @@ https://build.opensuse.org/package/show/openSUSE:Leap:15.3:Images/JeOS
             </oemconfig>
         </type>
     </preferences>
-    <preferences profiles="Leap15.3.ARM64EFI">
+    <preferences profiles="Leap15.3.ARM64EFI,Leap15.4.ARM64EFI,Tumbleweed.ARM64EFI">
         <!--Change to reflect the Rockstor version used #.#.# (rpm version) -# (rpm release)-->
-        <version>4.1.0-0</version>
+        <version>4.5.4-0</version>
         <packagemanager>zypper</packagemanager>
         <locale>en_GB</locale>
         <keytable>gb</keytable>
@@ -213,8 +228,13 @@ https://build.opensuse.org/package/show/openSUSE:Leap:15.3:Images/JeOS
                 profiles="Leap15.3.x86_64,Leap15.3.RaspberryPi4,Leap15.3.ARM64EFI">
         <source path="obs://Virtualization:Appliances:Builder/openSUSE_Leap_15.3"/>
     </repository>
+    <!-- Leap 15.4 Virtualization is x86_64 only, using default distro kiwi-ng version -->
+    <!--    <repository type="rpm-md" alias="kiwi" priority="1"-->
+    <!--                profiles="Leap15.4.x86_64,Leap15.4.RaspberryPi4,Leap15.4.ARM64EFI">-->
+    <!--        <source path="obs://Virtualization:Appliances:Builder/openSUSE_Leap_15.4"/>-->
+    <!--    </repository>-->
     <repository type="rpm-md" alias="kiwi" priority="1"
-                profiles="Tumbleweed.x86_64">
+                profiles="Tumbleweed.x86_64,Tumbleweed.RaspberryPi4,Tumbleweed.ARM64EFI">
         <source path="obs://Virtualization:Appliances:Builder/openSUSE_Tumbleweed"/>
     </repository>
     <!-- https://en.opensuse.org/Package_repositories -->
@@ -224,15 +244,27 @@ https://build.opensuse.org/package/show/openSUSE:Leap:15.3:Images/JeOS
                 profiles="Leap15.3.x86_64,Leap15.3.RaspberryPi4,Leap15.3.ARM64EFI">
         <source path="obs://openSUSE:Leap:15.3/standard"/>
     </repository>
+    <repository type="rpm-md" alias="Leap_15_4" imageinclude="true"
+                profiles="Leap15.4.x86_64,Leap15.4.RaspberryPi4,Leap15.4.ARM64EFI">
+        <source path="obs://openSUSE:Leap:15.4/standard"/>
+    </repository>
     <repository type="rpm-md" alias="Tumbleweed" imageinclude="true"
                 profiles="Tumbleweed.x86_64">
         <source path="obs://openSUSE:Tumbleweed/standard"/>
+    </repository>
+    <repository type="rpm-md" alias="Tumbleweed" imageinclude="true"
+                profiles="Tumbleweed.RaspberryPi4,Tumbleweed.ARM64EFI">
+        <source path="https://download.opensuse.org/ports/aarch64/tumbleweed/repo/oss/"/>
     </repository>
     <!-- Alias repo-update Name="Main Update Repository" or "openSUSE-Tumbleweed-Update" in JeOS-->
     <!-- Leap 15.3 repo now multi architecture -->
     <repository type="rpm-md" alias="Leap_15_3_Updates" imageinclude="true"
                 profiles="Leap15.3.x86_64,Leap15.3.RaspberryPi4,Leap15.3.ARM64EFI">
         <source path="https://download.opensuse.org/update/leap/15.3/oss/"/>
+    </repository>
+    <repository type="rpm-md" alias="Leap_15_4_Updates" imageinclude="true"
+                profiles="Leap15.4.x86_64,Leap15.4.RaspberryPi4,Leap15.4.ARM64EFI">
+        <source path="https://download.opensuse.org/update/leap/15.4/oss/"/>
     </repository>
     <repository type="rpm-md" alias="Tumbleweed_Updates" imageinclude="true"
                 profiles="Tumbleweed.x86_64">
@@ -250,9 +282,17 @@ https://build.opensuse.org/package/show/openSUSE:Leap:15.3:Images/JeOS
                 profiles="Leap15.3.x86_64,Leap15.3.RaspberryPi4,Leap15.3.ARM64EFI">
         <source path="https://download.opensuse.org/update/leap/15.3/backports/"/>
     </repository>
+    <repository type="rpm-md" alias="repo-backports-update"
+                profiles="Leap15.4.x86_64,Leap15.4.RaspberryPi4,Leap15.4.ARM64EFI">
+        <source path="https://download.opensuse.org/update/leap/15.4/backports/"/>
+    </repository>
     <repository type="rpm-md" alias="repo-sle-update"
                 profiles="Leap15.3.x86_64,Leap15.3.RaspberryPi4,Leap15.3.ARM64EFI">
         <source path="https://download.opensuse.org/update/leap/15.3/sle/"/>
+    </repository>
+    <repository type="rpm-md" alias="repo-sle-update"
+                profiles="Leap15.4.x86_64,Leap15.4.RaspberryPi4,Leap15.4.ARM64EFI">
+        <source path="https://download.opensuse.org/update/leap/15.4/sle/"/>
     </repository>
     <!-- https://osinside.github.io/kiwi/working_with_kiwi/xml_description.html#adding-repositories -->
     <!-- Local-Repository on build host: for pre-installed rockstor package -->
@@ -268,8 +308,13 @@ https://build.opensuse.org/package/show/openSUSE:Leap:15.3:Images/JeOS
                 profiles="Leap15.3.RaspberryPi4,Leap15.3.ARM64EFI">
         <source path="http://updates.rockstor.com:8999/rockstor-testing/leap/15.3_aarch64/"/>
     </repository>
+    <!-- Rockstor repos are multi-arch from 15.4 onwards -->
     <repository type="rpm-md" alias="Rockstor-Testing"
-                profiles="Tumbleweed.x86_64">
+                profiles="Leap15.4.x86_64,Leap15.4.RaspberryPi4,Leap15.4.ARM64EFI">
+        <source path="http://updates.rockstor.com:8999/rockstor-testing/leap/15.4/"/>
+    </repository>
+    <repository type="rpm-md" alias="Rockstor-Testing"
+                profiles="Tumbleweed.x86_64,Tumbleweed.RaspberryPi4,Tumbleweed.ARM64EFI">
         <source path="http://updates.rockstor.com:8999/rockstor-testing/tumbleweed/"/>
     </repository>
     <!-- For shellinabox package -->
@@ -283,9 +328,13 @@ https://build.opensuse.org/package/show/openSUSE:Leap:15.3:Images/JeOS
                 profiles="Leap15.3.x86_64,Leap15.3.RaspberryPi4,Leap15.3.ARM64EFI">
         <source path="https://download.opensuse.org/repositories/home:/rockstor/openSUSE_Leap_15.3/"/>
     </repository>
-    <repository type="rpm-md" alias="shells" priority="105" imageinclude="true"
-                profiles="Tumbleweed.x86_64">
-        <source path="https://download.opensuse.org/repositories/shells/openSUSE_Tumbleweed/"/>
+    <repository type="rpm-md" alias="home_rockstor" priority="105" imageinclude="true"
+                profiles="Leap15.4.x86_64,Leap15.4.RaspberryPi4,Leap15.4.ARM64EFI">
+        <source path="https://download.opensuse.org/repositories/home:/rockstor/15.4/"/>
+    </repository>
+    <repository type="rpm-md" alias="home_rockstor" priority="105" imageinclude="true"
+                profiles="Tumbleweed.x86_64,Tumbleweed.RaspberryPi4,Tumbleweed.ARM64EFI">
+        <source path="https://download.opensuse.org/repositories/home:/rockstor/openSUSE_Tumbleweed/"/>
     </repository>
     <!-- As per https://en.opensuse.org/Archive:Making_an_openSUSE_based_distribution -->
     <!-- We are required to de/re-brand packages that have no "...branding-upstream" equivalent-->
@@ -296,10 +345,13 @@ https://build.opensuse.org/package/show/openSUSE:Leap:15.3:Images/JeOS
                 profiles="Leap15.3.x86_64,Leap15.3.RaspberryPi4,Leap15.3.ARM64EFI">
         <source path="https://download.opensuse.org/repositories/home:/rockstor:/branches:/Base:/System/openSUSE_Leap_15.3/"/>
     </repository>
-    <!-- TODO: Only a factory option, no tumbleweed option so factory for now -->
     <repository type="rpm-md" alias="home_rockstor_branches_Base_System" priority="97" imageinclude="true"
-                profiles="Tumbleweed.x86_64">
-        <source path="https://download.opensuse.org/repositories/home:/rockstor:/branches:/Base:/System/openSUSE_Factory/"/>
+                profiles="Leap15.4.x86_64,Leap15.4.RaspberryPi4,Leap15.4.ARM64EFI">
+        <source path="https://download.opensuse.org/repositories/home:/rockstor:/branches:/Base:/System/15.4/"/>
+    </repository>
+    <repository type="rpm-md" alias="home_rockstor_branches_Base_System" priority="97" imageinclude="true"
+                profiles="Tumbleweed.x86_64,Tumbleweed.RaspberryPi4,Tumbleweed.ARM64EFI">
+        <source path="https://download.opensuse.org/repositories/home:/rockstor:/branches:/Base:/System/openSUSE_Tumbleweed/"/>
     </repository>
     <!-- For Traverse Ten64 drivers -->
     <!-- https://build.opensuse.org/project/show/home:mcbridematt  -->
@@ -316,21 +368,21 @@ https://build.opensuse.org/package/show/openSUSE:Leap:15.3:Images/JeOS
     <!-- Kernel HEAD Backports -->
     <!-- https://build.opensuse.org/repositories/Kernel:HEAD:Backport -->
     <!--    <repository type="rpm-md" alias="Kernel_HEAD_Backport" imageinclude="true"-->
-    <!--                profiles="Leap15.3.x86_64,Leap15.3.RaspberryPi4,Leap15.3.ARM64EFI">-->
+    <!--                profiles="Leap15.4.x86_64,Leap15.4.RaspberryPi4,Leap15.4.ARM64EFI">-->
     <!--        <source path="https://download.opensuse.org/repositories/Kernel:/HEAD:/Backport/standard/"/>-->
     <!--    </repository>-->
     <!-- Kernel Stable Backports -->
     <!-- https://build.opensuse.org/project/show/Kernel:stable:Backport -->
     <!-- See also: https://rockstor.com/docs/howtos/stable_kernel_backport.html  -->
     <!--    <repository type="rpm-md" alias="Kernel_stable_Backport" imageinclude="true"-->
-    <!--                profiles="Leap15.3.x86_64,Leap15.3.RaspberryPi4,Leap15.3.ARM64EFI">-->
+    <!--                profiles="Leap15.4.x86_64,Leap15.4.RaspberryPi4,Leap15.4.ARM64EFI">-->
     <!--        <source path="https://download.opensuse.org/repositories/Kernel:/stable:/Backport/standard/"/>-->
     <!--    </repository>-->
     <!-- btrfs-progs backport via filesystems repo -->
     <!-- https://build.opensuse.org/project/show/filesystems -->
     <!--    <repository type="rpm-md" alias="filesystems" imageinclude="true"-->
-    <!--                profiles="Leap15.3.x86_64,Leap15.3.RaspberryPi4,Leap15.3.ARM64EFI">-->
-    <!--        <source path="https://download.opensuse.org/repositories/filesystems/15.3/"/>-->
+    <!--                profiles="Leap15.4.x86_64,Leap15.4.RaspberryPi4,Leap15.4.ARM64EFI">-->
+    <!--        <source path="https://download.opensuse.org/repositories/filesystems/15.4/"/>-->
     <!--    </repository>-->
     <packages type="image">
         <package name="adaptec-firmware"/>  <!--Razor AIC94xx Series SAS-->
@@ -393,55 +445,14 @@ https://build.opensuse.org/package/show/openSUSE:Leap:15.3:Images/JeOS
         <package name="tree"/>
         <package name="vim"/>
         <package name="which"/>
+        <package name="ntfs-3g"/>
         <!-- Fix choice between kernel-firmware and kernel-firmware-all -->
         <!-- <package name="kernel-firmware"/> -->
-        <!--ADDITIONAL ROCKSTOR DEPENDENCIES-->
-        <package name="at"/>
-        <package name="avahi"/>
-        <package name="chrony"/>
-        <package name="cronie"/>  <!--new cron daemon: has mailx as hard dependency -->
-        <package name="cyrus-sasl-plain"/>
-        <package name="dnf-plugins-core"/>  <!--for changelog capability-->
-        <package name="dnf-yum"/>  <!--modern yum look-a-like.-->
-        <package name="docker"/>  <!--had criu git-core as recommended-->
-        <package name="firewalld"/>  <!--Could drop as we just turn it off-->
-        <package name="haveged"/>
-        <package name="hdparm"/>
-        <package name="krb5-client"/>
-        <package name="net-snmp"/>
-        <package name="nfs-kernel-server"/>
-        <package name="nginx"/>
-        <package name="ntfs-3g"/>
-        <package name="ntp"/>  <!--would seem redundant with chrony-->
-        <package name="nut"/>
-        <package name="nut-drivers-net"/>
-        <package name="postfix"/>
-        <package name="postgresql10"/>
-        <package name="postgresql10-server"/>
-        <package name="python-xml"/>
-        <package name="python2-chardet"/>  <!--python3-chardet available-->
-        <package name="python2-distro"/>  <!--For rockstor package-->
-        <package name="python2-psycopg2"/>
-        <package name="python2-pyzmq"/>
-        <package name="python2-requests"/>  <!--Needed by api_wrapper.py-->
-        <package name="python2-setuptools"/>  <!--pkg_resources supervisorctl-->
-        <package name="python2-six"/>
-        <package name="python3-distro"/>  <!--dnf-plugins-core dep-->
-        <package name="python3-python-dateutil"/>  <!--dnf-plugins-core dep-->
-        <package name="realmd"/>
-        <package name="realmd-lang"/>  <!--as 'no-recommends' would skip-->
-        <package name="rsync"/>
-        <package name="samba"/>  <!--we miss cron via 'no-recommends'-->
-        <package name="samba-winbind"/>
-        <package name="shellinabox"/>  <!--for embedded Web-UI console-->
-        <package name="smartmontools"/>
-        <package name="systemtap-runtime"/>
-        <package name="ypbind"/>
-        <!--ROCKSTOR PACKAGE-->
-        <!--Change to reflect the version specified, i.e. 4.1.0-0-->
-        <package name="rockstor-4.1.0-0"/>
+        <!--ROCKSTOR PACKAGE WITH MANY ADDITIONAL DISTRO SPECIFIC DEPENDENCIES-->
+        <!--Change to reflect the version specified, i.e. 4.5.4-0-->
+        <package name="rockstor-4.5.4-0"/>
     </packages>
-    <packages type="image" profiles="Leap15.3.RaspberryPi4">
+    <packages type="image" profiles="Leap15.3.RaspberryPi4,Leap15.4.RaspberryPi4,Tumbleweed.RaspberryPi4">
         <package name="raspberrypi-eeprom" arch="aarch64"/>
         <package name="raspberrypi-firmware" arch="aarch64"/>
         <package name="raspberrypi-firmware-config" arch="aarch64"/>


### PR DESCRIPTION
## Includes:
- Updating Tumbleweed profiles for possible future.
- Removing explicit dependencies of rockstor package.
- Moving to Stable Release Candidate rockstor package 4.5.4.
- Moving ntfs-3g to base os as not a rockstor dependency.

Fixes #123 
@FroggyFlox Ready for review: I see some cosmetic issues still on one of our Tumbleweed profiles and the loss of info about them being experimental and not yet tested but otherwise this looks to be ready for our 4.5.4-0 rpm testing release designated as a Stable RC1 hopefully.