### PR TITLE
update default version to 4.5.6-0 #130

### DIFF
--- a/rockstor.kiwi
+++ b/rockstor.kiwi
@@ -110,7 +110,7 @@ https://build.opensuse.org/package/show/openSUSE:Leap:15.3:Images/JeOS
 
     <preferences profiles="Leap15.3.RaspberryPi4,Leap15.4.RaspberryPi4,Tumbleweed.RaspberryPi4">
         <!--Change to reflect the Rockstor version used #.#.# (rpm version) -# (rpm release)-->
-        <version>4.5.5-0</version>
+        <version>4.5.6-0</version>
         <packagemanager>zypper</packagemanager>
         <locale>en_GB</locale>
         <keytable>gb</keytable>
@@ -161,7 +161,7 @@ https://build.opensuse.org/package/show/openSUSE:Leap:15.3:Images/JeOS
     </preferences>
     <preferences profiles="Leap15.3.ARM64EFI,Leap15.4.ARM64EFI,Tumbleweed.ARM64EFI">
         <!--Change to reflect the Rockstor version used #.#.# (rpm version) -# (rpm release)-->
-        <version>4.5.5-0</version>
+        <version>4.5.6-0</version>
         <packagemanager>zypper</packagemanager>
         <locale>en_GB</locale>
         <keytable>gb</keytable>
@@ -449,8 +449,8 @@ https://build.opensuse.org/package/show/openSUSE:Leap:15.3:Images/JeOS
         <!-- Fix choice between kernel-firmware and kernel-firmware-all -->
         <!-- <package name="kernel-firmware"/> -->
         <!--ROCKSTOR PACKAGE WITH MANY ADDITIONAL DISTRO SPECIFIC DEPENDENCIES-->
-        <!--Change to reflect the version specified, i.e. 4.5.5-0-->
-        <package name="rockstor-4.5.5-0"/>
+        <!--Change to reflect the version specified, i.e. 4.5.6-0-->
+        <package name="rockstor-4.5.6-0"/>
     </packages>
     <packages type="image" profiles="Leap15.3.RaspberryPi4,Leap15.4.RaspberryPi4,Tumbleweed.RaspberryPi4">
         <package name="raspberrypi-eeprom" arch="aarch64"/>


### PR DESCRIPTION
Use the latest stable release candidate version from the current testing channel.

Fixes #130 