### PR TITLE
Remove deleted upstream Ten64 repo "Leap15.3.ARM64EFI" #138

### DIFF
--- a/rockstor.kiwi
+++ b/rockstor.kiwi
@@ -353,12 +353,6 @@ https://build.opensuse.org/package/show/openSUSE:Leap:15.3:Images/JeOS
                 profiles="Tumbleweed.x86_64,Tumbleweed.RaspberryPi4,Tumbleweed.ARM64EFI">
         <source path="https://download.opensuse.org/repositories/home:/rockstor:/branches:/Base:/System/openSUSE_Tumbleweed/"/>
     </repository>
-    <!-- For Traverse Ten64 drivers -->
-    <!-- https://build.opensuse.org/project/show/home:mcbridematt  -->
-    <repository type="rpm-md" alias="mcbridematt" imageinclude="true"
-                profiles="Leap15.3.ARM64EFI">
-        <source path="obs://home:mcbridematt/openSUSE_Leap_15.3/" />
-    </repository>
     <!-- THE FOLLOWING KERNEL REPOS ARE NOT SUPPORTED. -->
     <!-- Provided here remarked-out for developer convenience only. -->
     <!-- https://doc.opensuse.org/documentation/leap/reference/html/book-reference/cha-tuning-multikernel.html -->


### PR DESCRIPTION
This repository has now been removed. Re-enable installer profile by removing.
N.B. the base OS of this profile is now EOL and as such will be removed entirely very soon.

Fixes #138 