### PR TITLE
Remove Leap 15.3 profiles #126

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,9 +16,9 @@ With the latter ARM64EFI spanning both generic (Arm64) and specific (64 bit EFI)
 ## Core Profiles
 Our current pre-built installers, see: [Downloads](https://rockstor.com/dls.html), are built using the following profiles:
 
-- **Leap15.3.x86_64**
-- **Leap15.3.RaspberryPi4** (supports RPi400 also)
-- **Leap15.3.ARM64EFI** (N.B. Full Ten64 compatibility awaiting mcbridematt repo update)
+- **Leap15.4.x86_64**
+- **Leap15.4.RaspberryPi4** (supports RPi400 also)
+- **Leap15.4.ARM64EFI** (N.B. Full Ten64 compatibility awaiting mcbridematt repo update)
 
 ### Contributing a Profile
 If you would like to add a specific target system installer profile, please take a look at the [examples](https://github.com/OSInside/kiwi-descriptions) referenced in the second link above.
@@ -57,7 +57,7 @@ Note that this is not a supported configuration so do indicate this modification
 Please see the [overview](https://osinside.github.io/kiwi/overview.html) section of the kiwi-ng docs for the canonical
 [System Requirements](https://osinside.github.io/kiwi/overview.html#system-requirements) for building the installer: e.g. 15 GB free space, Python 3.5+ etc.
 
-Given our image target OS is exclusively 'Built on openSUSE', a vanilla openSUSE Leap 15.3 install is recommended if not using the kiwi-ng boxbuild method.
+Given our image target OS is exclusively 'Built on openSUSE', a vanilla openSUSE Leap 15.4 install is recommended if not using the kiwi-ng boxbuild method.
 But if the newer kiwi-ng boxbuild method in "Building on any linux host... " is used, any relatively modern linux system can be used to build the installer.
 
 ### rockstor-installer local copy
@@ -72,7 +72,7 @@ git clone https://github.com/rockstor/rockstor-installer.git
 cd rockstor-installer/
 ```  
 
-The above commands install the 'git' program, and uses it to 'clone' (read copy locally) the GitHub repo, then sets your working directory to be inside this local copy.
+The above commands install the 'git' program, and use it to 'clone' (read copy locally) the GitHub repo, before setting your working directory to be inside this local copy.
 Now you just need the kiwi-ng program this config requires to make the final installer. 
 
 ### Building on any linux host (KVM support required)
@@ -110,7 +110,7 @@ Or go with the explicit version 3.x of pip:
 ```
 The rest remains the same (make sure to consider the memory and CPU defaults mentioned above)
 ```shell
-./kiwi-env/bin/kiwi-ng --profile=Leap15.3.x86_64 --type oem \
+./kiwi-env/bin/kiwi-ng --profile=Leap15.4.x86_64 --type oem \
   system boxbuild --box leap -- --description ./ --target-dir ./images
 ```
 
@@ -118,31 +118,31 @@ The rest remains the same (make sure to consider the memory and CPU defaults men
 This was the preferred method before the above kiwi-ng boxbuild capability existed.
 
 #### kiwi-ng install
-For an openSUSE Leap 15.3 OS from kiwi-ng's doc [Installation](https://osinside.github.io/kiwi/installation.html#installation) section we have:
+For an openSUSE Leap 15.4 OS from kiwi-ng's doc [Installation](https://osinside.github.io/kiwi/installation.html#installation) section we have:
 
 #### x86_64 host for x86_64 profiles
 Any x86_64 machine, although keep in mind that building the ISO installer is computationally expensive so Haswell or better is recommended.
 
-##### Leap 15.3 host
+##### Leap 15.4 host
 The openSUSE host version should, ideally, be at least the version of the target profile.
 ```shell
-sudo zypper addrepo http://download.opensuse.org/repositories/Virtualization:/Appliances:/Builder/openSUSE_Leap_15.3/ appliance-builder
+sudo zypper addrepo http://download.opensuse.org/repositories/Virtualization:/Appliances:/Builder/openSUSE_Leap_15.4/ appliance-builder
 sudo zypper install python3-kiwi btrfsprogs gfxboot qemu-tools gptfdisk e2fsprogs squashfs xorriso dosfstools
 ```
 
 #### AArch64 host (e.g. a Pi4) for AArch64 profiles
 See [HCL:Raspberry Pi4](https://en.opensuse.org/HCL:Raspberry_Pi4).
-Install, for example, an appliance JeOS Leap 15.3 image as the host OS.
+Install, for example, an appliance JeOS Leap 15.4 image as the host OS.
 Enabling USB boot on older Pi4 systems will allow for the use of, for example, an SSD as the system drive which will massively speed up installer building.
 USB booting on the Pi4 may require a bootloader update via a fully updated Raspberry OS.
 
 Pi4 EEPROM/bootloader version "Jun 15 2020" or later will be required for USB boot regardless of any installer /EFI file changes.
 
-##### For a JeOS Leap 15.3 host:
-(Leap 15.3 has moved to mixed X86_64/aarch64 repos) 
+##### For a JeOS Leap 15.4 host:
+(Leap 15.3 and higher has moved to mixed X86_64/aarch64 repos) 
 
 ```shell
-sudo zypper addrepo https://download.opensuse.org/repositories/Virtualization:/Appliances:/Builder/openSUSE_Leap_15.3/ appliance-builder
+sudo zypper addrepo https://download.opensuse.org/repositories/Virtualization:/Appliances:/Builder/openSUSE_Leap_15.4/ appliance-builder
 sudo zypper install python3-kiwi btrfsprogs qemu-tools gptfdisk e2fsprogs squashfs xorriso dosfstools
 ```
 
@@ -151,17 +151,17 @@ No edit is required if you wish to use the generic installer filename and defaul
 To change these defaults edit all lines directly preceded by **<!--Change to ...** as per the **...** details given.
 Our release infrastructure performs these same edits to set official installer filenames and rockstor package versions.
 
-### Leap15.3.x86_64 profile
-Executed, as the root user, in the directory containing this repositories rockstor.kiwi file.
+### Leap15.4.x86_64 profile
+Executed, as the root user, in the directory containing this repository's rockstor.kiwi file.
 ```shell
-kiwi-ng --profile=Leap15.3.x86_64 --type oem system build --description ./ --target-dir /home/kiwi-images/
+kiwi-ng --profile=Leap15.4.x86_64 --type oem system build --description ./ --target-dir /home/kiwi-images/
 ```
 
-### Leap15.3.RaspberryPi4 profile
-Executed, as the root user, in the directory containing this repositories rockstor.kiwi file.
+### Leap15.4.RaspberryPi4 profile
+Executed, as the root user, in the directory containing this repository's rockstor.kiwi file.
 N.B. RPi400 built in keyboard is known not to work with this profile. 
 ```shell
-kiwi-ng --profile=Leap15.3.RaspberryPi4 --type oem system build --description ./ --target-dir /home/kiwi-images/
+kiwi-ng --profile=Leap15.4.RaspberryPi4 --type oem system build --description ./ --target-dir /home/kiwi-images/
 ```
 
 ## Resulting Rockstor installers

--- a/rockstor.kiwi
+++ b/rockstor.kiwi
@@ -23,15 +23,6 @@ https://build.opensuse.org/package/show/openSUSE:Leap:15.3:Images/JeOS
         <!-- For preferences, drivers, repository, packages, and users elements -->
         <!-- https://osinside.github.io/kiwi/working_with_kiwi/xml_description.html#image-profiles-->
         <!-- N.B. can inherit one profile within another via requires profile="" -->
-        <profile name="Leap15.3.x86_64"
-                 description="Rockstor built on openSUSE Leap 15.3 x86_64"
-                 arch="x86_64"/>
-        <profile name="Leap15.3.RaspberryPi4"
-                 description="Rockstor built on openSUSE Leap 15.3 Raspberry_Pi"
-                 arch="aarch64"/>
-        <profile name="Leap15.3.ARM64EFI"
-                 description="Rockstor built on openSUSE Leap 15.3 ARM64 EFI/VM/Ten64"
-                 arch="aarch64"/>
         <profile name="Leap15.4.x86_64"
                  description="Rockstor built on openSUSE Leap 15.4 x86_64"
                  arch="x86_64"/>
@@ -53,7 +44,7 @@ https://build.opensuse.org/package/show/openSUSE:Leap:15.3:Images/JeOS
                  description="Rockstor built on openSUSE Tumbleweed ARM64 EFI/VM/Ten64"
                  arch="aarch64"/>
     </profiles>
-    <preferences profiles="Leap15.3.x86_64,Leap15.4.x86_64,Tumbleweed.x86_64">
+    <preferences profiles="Leap15.4.x86_64,Tumbleweed.x86_64">
         <!--Change to reflect the Rockstor version used #.#.# (rpm version) -# (rpm release)-->
         <version>4.5.8-0</version>
         <packagemanager>zypper</packagemanager>
@@ -108,7 +99,7 @@ https://build.opensuse.org/package/show/openSUSE:Leap:15.3:Images/JeOS
         </type>
     </preferences>
 
-    <preferences profiles="Leap15.3.RaspberryPi4,Leap15.4.RaspberryPi4,Tumbleweed.RaspberryPi4">
+    <preferences profiles="Leap15.4.RaspberryPi4,Tumbleweed.RaspberryPi4">
         <!--Change to reflect the Rockstor version used #.#.# (rpm version) -# (rpm release)-->
         <version>4.5.8-0</version>
         <packagemanager>zypper</packagemanager>
@@ -159,7 +150,7 @@ https://build.opensuse.org/package/show/openSUSE:Leap:15.3:Images/JeOS
             </oemconfig>
         </type>
     </preferences>
-    <preferences profiles="Leap15.3.ARM64EFI,Leap15.4.ARM64EFI,Tumbleweed.ARM64EFI">
+    <preferences profiles="Leap15.4.ARM64EFI,Tumbleweed.ARM64EFI">
         <!--Change to reflect the Rockstor version used #.#.# (rpm version) -# (rpm release)-->
         <version>4.5.8-0</version>
         <packagemanager>zypper</packagemanager>
@@ -223,11 +214,6 @@ https://build.opensuse.org/package/show/openSUSE:Leap:15.3:Images/JeOS
     </users>
     <!-- For zypper priority 1 is highest, priority 0 returns to default of 99 -->
     <!-- https://build.opensuse.org/project/show/Virtualization:Appliances:Builder -->
-    <!-- Leap 15.3 repo now dual architecture -->
-    <repository type="rpm-md" alias="kiwi" priority="1"
-                profiles="Leap15.3.x86_64,Leap15.3.RaspberryPi4,Leap15.3.ARM64EFI">
-        <source path="obs://Virtualization:Appliances:Builder/openSUSE_Leap_15.3"/>
-    </repository>
     <!-- Leap 15.4 Virtualization is x86_64 only, using default distro kiwi-ng version -->
     <!--    <repository type="rpm-md" alias="kiwi" priority="1"-->
     <!--                profiles="Leap15.4.x86_64,Leap15.4.RaspberryPi4,Leap15.4.ARM64EFI">-->
@@ -239,11 +225,6 @@ https://build.opensuse.org/package/show/openSUSE:Leap:15.3:Images/JeOS
     </repository>
     <!-- https://en.opensuse.org/Package_repositories -->
     <!-- Alias repo-oss Name="Main Repository" in JeOS-->
-    <!-- Leap 15.3 repo now multi architecture -->
-    <repository type="rpm-md" alias="Leap_15_3" imageinclude="true"
-                profiles="Leap15.3.x86_64,Leap15.3.RaspberryPi4,Leap15.3.ARM64EFI">
-        <source path="obs://openSUSE:Leap:15.3/standard"/>
-    </repository>
     <repository type="rpm-md" alias="Leap_15_4" imageinclude="true"
                 profiles="Leap15.4.x86_64,Leap15.4.RaspberryPi4,Leap15.4.ARM64EFI">
         <source path="obs://openSUSE:Leap:15.4/standard"/>
@@ -257,11 +238,6 @@ https://build.opensuse.org/package/show/openSUSE:Leap:15.3:Images/JeOS
         <source path="https://download.opensuse.org/ports/aarch64/tumbleweed/repo/oss/"/>
     </repository>
     <!-- Alias repo-update Name="Main Update Repository" or "openSUSE-Tumbleweed-Update" in JeOS-->
-    <!-- Leap 15.3 repo now multi architecture -->
-    <repository type="rpm-md" alias="Leap_15_3_Updates" imageinclude="true"
-                profiles="Leap15.3.x86_64,Leap15.3.RaspberryPi4,Leap15.3.ARM64EFI">
-        <source path="https://download.opensuse.org/update/leap/15.3/oss/"/>
-    </repository>
     <repository type="rpm-md" alias="Leap_15_4_Updates" imageinclude="true"
                 profiles="Leap15.4.x86_64,Leap15.4.RaspberryPi4,Leap15.4.ARM64EFI">
         <source path="https://download.opensuse.org/update/leap/15.4/oss/"/>
@@ -279,16 +255,8 @@ https://build.opensuse.org/package/show/openSUSE:Leap:15.3:Images/JeOS
     <!-- Not included in image as auto added by installed system. -->
     <!-- Used during image build to capture updates at time of installer build -->
     <repository type="rpm-md" alias="repo-backports-update"
-                profiles="Leap15.3.x86_64,Leap15.3.RaspberryPi4,Leap15.3.ARM64EFI">
-        <source path="https://download.opensuse.org/update/leap/15.3/backports/"/>
-    </repository>
-    <repository type="rpm-md" alias="repo-backports-update"
                 profiles="Leap15.4.x86_64,Leap15.4.RaspberryPi4,Leap15.4.ARM64EFI">
         <source path="https://download.opensuse.org/update/leap/15.4/backports/"/>
-    </repository>
-    <repository type="rpm-md" alias="repo-sle-update"
-                profiles="Leap15.3.x86_64,Leap15.3.RaspberryPi4,Leap15.3.ARM64EFI">
-        <source path="https://download.opensuse.org/update/leap/15.3/sle/"/>
     </repository>
     <repository type="rpm-md" alias="repo-sle-update"
                 profiles="Leap15.4.x86_64,Leap15.4.RaspberryPi4,Leap15.4.ARM64EFI">
@@ -300,14 +268,6 @@ https://build.opensuse.org/package/show/openSUSE:Leap:15.3:Images/JeOS
     <!--        <source path="dir:/mnt/localrepo"/>-->
     <!--    </repository>-->
     <!-- Resource Rockstor Testing channel during installer build only -->
-    <repository type="rpm-md" alias="Rockstor-Testing"
-                profiles="Leap15.3.x86_64">
-        <source path="http://updates.rockstor.com:8999/rockstor-testing/leap/15.3/"/>
-    </repository>
-    <repository type="rpm-md" alias="Rockstor-Testing"
-                profiles="Leap15.3.RaspberryPi4,Leap15.3.ARM64EFI">
-        <source path="http://updates.rockstor.com:8999/rockstor-testing/leap/15.3_aarch64/"/>
-    </repository>
     <!-- Rockstor repos are multi-arch from 15.4 onwards -->
     <repository type="rpm-md" alias="Rockstor-Testing"
                 profiles="Leap15.4.x86_64,Leap15.4.RaspberryPi4,Leap15.4.ARM64EFI">
@@ -325,10 +285,6 @@ https://build.opensuse.org/package/show/openSUSE:Leap:15.3:Images/JeOS
     <!-- Maintain lower priority to upstream in case shellinabox is added there -->
     <!-- https://build.opensuse.org/project/show/home:rockstor -->
     <repository type="rpm-md" alias="home_rockstor" priority="105" imageinclude="true"
-                profiles="Leap15.3.x86_64,Leap15.3.RaspberryPi4,Leap15.3.ARM64EFI">
-        <source path="https://download.opensuse.org/repositories/home:/rockstor/openSUSE_Leap_15.3/"/>
-    </repository>
-    <repository type="rpm-md" alias="home_rockstor" priority="105" imageinclude="true"
                 profiles="Leap15.4.x86_64,Leap15.4.RaspberryPi4,Leap15.4.ARM64EFI">
         <source path="https://download.opensuse.org/repositories/home:/rockstor/15.4/"/>
     </repository>
@@ -340,11 +296,6 @@ https://build.opensuse.org/package/show/openSUSE:Leap:15.3:Images/JeOS
     <!-- We are required to de/re-brand packages that have no "...branding-upstream" equivalent-->
     <!-- This repo currently provides: systemd-presets-branding-rockstor -->
     <!-- https://build.opensuse.org/package/show/home:rockstor:branches:Base:System/systemd-presets-branding-rockstor -->
-    <!-- Leap 15.3 repo now multi architecture -->
-    <repository type="rpm-md" alias="home_rockstor_branches_Base_System" priority="97" imageinclude="true"
-                profiles="Leap15.3.x86_64,Leap15.3.RaspberryPi4,Leap15.3.ARM64EFI">
-        <source path="https://download.opensuse.org/repositories/home:/rockstor:/branches:/Base:/System/openSUSE_Leap_15.3/"/>
-    </repository>
     <repository type="rpm-md" alias="home_rockstor_branches_Base_System" priority="97" imageinclude="true"
                 profiles="Leap15.4.x86_64,Leap15.4.RaspberryPi4,Leap15.4.ARM64EFI">
         <source path="https://download.opensuse.org/repositories/home:/rockstor:/branches:/Base:/System/15.4/"/>
@@ -451,7 +402,7 @@ https://build.opensuse.org/package/show/openSUSE:Leap:15.3:Images/JeOS
         <!--Change to reflect the version specified, i.e. 4.5.8-0-->
         <package name="rockstor-4.5.8-0"/>
     </packages>
-    <packages type="image" profiles="Leap15.3.RaspberryPi4,Leap15.4.RaspberryPi4,Tumbleweed.RaspberryPi4">
+    <packages type="image" profiles="Leap15.4.RaspberryPi4,Tumbleweed.RaspberryPi4">
         <package name="raspberrypi-eeprom" arch="aarch64"/>
         <package name="raspberrypi-firmware" arch="aarch64"/>
         <package name="raspberrypi-firmware-config" arch="aarch64"/>


### PR DESCRIPTION
Fixes #126 
@phillxnet, @Hooverdan96: ready for review 

This commit simply removes all Leap 15.3 profiles from `rockstor.kiwi` and sets  Leap 15.4 as the new default example in `README.md`.

The new examples for x86_64 Leap 15.4 in the readme (using boxbuild or not) were verified to complete successfully).