### PR TITLE
Add Leap 15.5 profiles #146

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,13 +16,13 @@ With the latter ARM64EFI spanning both generic (Arm64) and specific (64 bit EFI)
 ## Core Profiles
 Our current pre-built installers, see: [Downloads](https://rockstor.com/dls.html), are built using the following profiles:
 
-- **Leap15.4.x86_64**
-- **Leap15.4.RaspberryPi4** (supports RPi400 also)
-- **Leap15.4.ARM64EFI** (N.B. Full Ten64 compatibility awaiting mcbridematt repo update)
+- **Leap15.5.x86_64**
+- **Leap15.5.RaspberryPi4** (supports RPi400 also)
+- **Leap15.5.ARM64EFI** (N.B. Full Ten64 compatibility awaiting mcbridematt repo update)
 
 ### Contributing a Profile
 If you would like to add a specific target system installer profile, please take a look at the [examples](https://github.com/OSInside/kiwi-descriptions) referenced in the second link above.
-The rockstor.kiwi file itself also contains comments with links to example configs used during it's development. 
+The `rockstor.kiwi` file itself also contains comments with links to example configs used during its development. 
 We can make no promises for the 'supported' status of any additional profiles but '[The Rockstor Project](https://rockstor.com/about-us.html)' will endeavour to make available the more popular resulting installers.
 
 ### Raspberry Pi4 Notes:
@@ -42,12 +42,12 @@ Please contribute to this profile if you are interested as we would very much li
 We are very excited to welcome contributions for the innovative [Traverse Ten64](https://www.crowdsupply.com/traverse-technologies/ten64) AArch64 platform.
 [Traverse technologies](https://traverse.com.au/) are an important contributor to the [rockstor-core](https://github.com/rockstor/rockstor-core) code base
 and have been instrumental in achieving our initial AArch64 aims.
-The resulting installer is intended to supports 64-bit ARM systems that implement the [Embedded Boot](https://github.com/ARM-software/ebbr) or [Server boot](https://github.com/ARM-software/sbsa-acs) standard.
+The resulting installer is intended to support 64-bit ARM systems that implement the [Embedded Boot](https://github.com/ARM-software/ebbr) or [Server boot](https://github.com/ARM-software/sbsa-acs) standard.
 Note that additional drives may be required for your specific hardware, if so consider [Installing the Stable Kernel Backport](https://rockstor.com/docs/howtos/stable_kernel_backport.html).
 Also see the following subsection for enabling these same repositories/facilities within the resulting installer itself.
 
 ### Stable Kernel Backport & matching btrfs-progs
-Note that we have, remarked out, the 'Stable Kernel Backport' and 'filesystems' repositories within our rockstor.kiwi config.
+Note that we have, remarked out, the 'Stable Kernel Backport' and 'filesystems' repositories within our `rockstor.kiwi` config.
 This enables building a custom installer with these back-ported modifications out-of-the-box.
 See [Installing the Stable Kernel Backport](https://rockstor.com/docs/howtos/stable_kernel_backport.html) for more information.
 Note that this is not a supported configuration so do indicate this modification if reporting issues on our forum or GitHub.
@@ -57,7 +57,7 @@ Note that this is not a supported configuration so do indicate this modification
 Please see the [overview](https://osinside.github.io/kiwi/overview.html) section of the kiwi-ng docs for the canonical
 [System Requirements](https://osinside.github.io/kiwi/overview.html#system-requirements) for building the installer: e.g. 15 GB free space, Python 3.5+ etc.
 
-Given our image target OS is exclusively 'Built on openSUSE', a vanilla openSUSE Leap 15.4 install is recommended if not using the kiwi-ng boxbuild method.
+Given our image target OS is exclusively 'Built on openSUSE', a vanilla openSUSE Leap 15.5 install is recommended if not using the kiwi-ng boxbuild method.
 But if the newer kiwi-ng boxbuild method in "Building on any linux host... " is used, any relatively modern linux system can be used to build the installer.
 
 ### rockstor-installer local copy
@@ -95,12 +95,12 @@ The recommendation in this case is to clone the installer git directly into the 
 At the end of installer creation the `.iso` file must then be copied from within the VM directory back onto the VM's host for further use.
 
 **Note on `pip` usage:**
-Some distros might still have a split between Python 2.x/3.x usage of `pip` (i.e. pip3 vs. pip), or an existing system that is being used had both installed over time. If that is the case, one wants to ensure that the 3.x version is used, by explicitly declaring `pip3` in the below command line. Otherwise this can lead to execution errors down the line.
+Some distros might still have a split between Python 2.x/3.x usage of `pip` (i.e. pip3 vs. pip), or an existing system that is being used had both installed over time. If that is the case, one wants to ensure that the 3.x version is used, by explicitly declaring `pip3` in the below command line. Otherwise, this can lead to execution errors down the line.
 
 ```shell
 python3 -m venv kiwi-env
 ```
-If the system/distro has dropped python 2.x support or it is not installed on the system that is used for the build:
+If the system/distro has dropped python 2.x support, or if it is not installed on the system that is used for the build:
 ```shell
 ./kiwi-env/bin/pip install kiwi kiwi-boxed-plugin
 ```
@@ -110,7 +110,7 @@ Or go with the explicit version 3.x of pip:
 ```
 The rest remains the same (make sure to consider the memory and CPU defaults mentioned above)
 ```shell
-./kiwi-env/bin/kiwi-ng --profile=Leap15.4.x86_64 --type oem \
+./kiwi-env/bin/kiwi-ng --profile=Leap15.5.x86_64 --type oem \
   system boxbuild --box leap -- --description ./ --target-dir ./images
 ```
 
@@ -118,31 +118,31 @@ The rest remains the same (make sure to consider the memory and CPU defaults men
 This was the preferred method before the above kiwi-ng boxbuild capability existed.
 
 #### kiwi-ng install
-For an openSUSE Leap 15.4 OS from kiwi-ng's doc [Installation](https://osinside.github.io/kiwi/installation.html#installation) section we have:
+For an openSUSE Leap 15.5 OS from kiwi-ng's doc [Installation](https://osinside.github.io/kiwi/installation.html#installation) section we have:
 
 #### x86_64 host for x86_64 profiles
 Any x86_64 machine, although keep in mind that building the ISO installer is computationally expensive so Haswell or better is recommended.
 
-##### Leap 15.4 host
+##### Leap 15.5 host
 The openSUSE host version should, ideally, be at least the version of the target profile.
 ```shell
-sudo zypper addrepo http://download.opensuse.org/repositories/Virtualization:/Appliances:/Builder/openSUSE_Leap_15.4/ appliance-builder
+sudo zypper addrepo http://download.opensuse.org/repositories/Virtualization:/Appliances:/Builder/openSUSE_Leap_15.5/ appliance-builder
 sudo zypper install python3-kiwi btrfsprogs gfxboot qemu-tools gptfdisk e2fsprogs squashfs xorriso dosfstools
 ```
 
 #### AArch64 host (e.g. a Pi4) for AArch64 profiles
 See [HCL:Raspberry Pi4](https://en.opensuse.org/HCL:Raspberry_Pi4).
-Install, for example, an appliance JeOS Leap 15.4 image as the host OS.
+Install, for example, an appliance JeOS Leap 15.5 image as the host OS.
 Enabling USB boot on older Pi4 systems will allow for the use of, for example, an SSD as the system drive which will massively speed up installer building.
 USB booting on the Pi4 may require a bootloader update via a fully updated Raspberry OS.
 
 Pi4 EEPROM/bootloader version "Jun 15 2020" or later will be required for USB boot regardless of any installer /EFI file changes.
 
-##### For a JeOS Leap 15.4 host:
+##### For a JeOS Leap 15.5 host:
 (Leap 15.3 and higher has moved to mixed X86_64/aarch64 repos) 
 
 ```shell
-sudo zypper addrepo https://download.opensuse.org/repositories/Virtualization:/Appliances:/Builder/openSUSE_Leap_15.4/ appliance-builder
+sudo zypper addrepo https://download.opensuse.org/repositories/Virtualization:/Appliances:/Builder/openSUSE_Leap_15.5/ appliance-builder
 sudo zypper install python3-kiwi btrfsprogs qemu-tools gptfdisk e2fsprogs squashfs xorriso dosfstools
 ```
 
@@ -151,17 +151,17 @@ No edit is required if you wish to use the generic installer filename and defaul
 To change these defaults edit all lines directly preceded by **<!--Change to ...** as per the **...** details given.
 Our release infrastructure performs these same edits to set official installer filenames and rockstor package versions.
 
-### Leap15.4.x86_64 profile
-Executed, as the root user, in the directory containing this repository's rockstor.kiwi file.
+### Leap15.5.x86_64 profile
+Executed, as the root user, in the directory containing this repository's `rockstor.kiwi` file.
 ```shell
-kiwi-ng --profile=Leap15.4.x86_64 --type oem system build --description ./ --target-dir /home/kiwi-images/
+kiwi-ng --profile=Leap15.5.x86_64 --type oem system build --description ./ --target-dir /home/kiwi-images/
 ```
 
-### Leap15.4.RaspberryPi4 profile
-Executed, as the root user, in the directory containing this repository's rockstor.kiwi file.
-N.B. RPi400 built in keyboard is known not to work with this profile. 
+### Leap15.5.RaspberryPi4 profile
+Executed, as the root user, in the directory containing this repository's `rockstor.kiwi` file.
+N.B. RPi400 built-in keyboard is known not to work with this profile. 
 ```shell
-kiwi-ng --profile=Leap15.4.RaspberryPi4 --type oem system build --description ./ --target-dir /home/kiwi-images/
+kiwi-ng --profile=Leap15.5.RaspberryPi4 --type oem system build --description ./ --target-dir /home/kiwi-images/
 ```
 
 ## Resulting Rockstor installers
@@ -179,7 +179,7 @@ Please see [Rockstor’s “Built on openSUSE” installer](https://rockstor.com
 ## Help or Assistance
 Our [friendly forum](https://forum.rockstor.com/) is a good place to ask question regarding this HowTo.
 Please be patient however as our support is predominantly community based and the above procedure is not that well known by our community members.
-If you find an issue with this procedure and it's associated kiwi-ng config, please consider submitting a pull request with any fixes or improvements you consequently discover or invent.
+If you find an issue with this procedure and its associated kiwi-ng config, please consider submitting a pull request with any fixes or improvements you consequently discover or invent.
 
 'The Rockstor Project' is a community endeavour and depends on [update channel](https://rockstor.com/docs/update-channels/update_channels.html)
 subscriptions and contributions for it's continued open source development.  

--- a/rockstor.kiwi
+++ b/rockstor.kiwi
@@ -4,8 +4,11 @@ https://osinside.github.io/kiwi/development/schema.html#schema-docs -->
 <!-- For reference we have:
 https://en.opensuse.org/Portal:JeOS
 https://documentation.suse.com/kiwi/9/single-html/kiwi/index.html
-https://build.opensuse.org/package/show/openSUSE:Leap:15.3/kiwi-templates-JeOS
-https://build.opensuse.org/package/show/openSUSE:Leap:15.3:Images/JeOS
+https://build.opensuse.org/package/show/openSUSE:Leap:15.5/kiwi-templates-Minimal
+https://build.opensuse.org/package/show/openSUSE:Leap:15.5:Images/kiwi-templates-Minimal
+https://build.opensuse.org/package/show/openSUSE:Leap:15.5:Images/JeOS
+
+
 -->
 <!-- OBS-Profiles: @BUILD_FLAVOR@ -->
 
@@ -23,6 +26,15 @@ https://build.opensuse.org/package/show/openSUSE:Leap:15.3:Images/JeOS
         <!-- For preferences, drivers, repository, packages, and users elements -->
         <!-- https://osinside.github.io/kiwi/working_with_kiwi/xml_description.html#image-profiles-->
         <!-- N.B. can inherit one profile within another via requires profile="" -->
+        <profile name="Leap15.5.x86_64"
+                 description="Rockstor built on openSUSE Leap 15.5 x86_64"
+                 arch="x86_64"/>
+        <profile name="Leap15.5.RaspberryPi4"
+                 description="Rockstor built on openSUSE Leap 15.5 Raspberry_Pi"
+                 arch="aarch64"/>
+        <profile name="Leap15.5.ARM64EFI"
+                 description="Rockstor built on openSUSE Leap 15.5 ARM64 EFI/VM/Ten64"
+                 arch="aarch64"/>
         <profile name="Leap15.4.x86_64"
                  description="Rockstor built on openSUSE Leap 15.4 x86_64"
                  arch="x86_64"/>
@@ -44,7 +56,7 @@ https://build.opensuse.org/package/show/openSUSE:Leap:15.3:Images/JeOS
                  description="Rockstor built on openSUSE Tumbleweed ARM64 EFI/VM/Ten64"
                  arch="aarch64"/>
     </profiles>
-    <preferences profiles="Leap15.4.x86_64,Tumbleweed.x86_64">
+    <preferences profiles="Leap15.4.x86_64,Leap15.5.x86_64,Tumbleweed.x86_64">
         <!--Change to reflect the Rockstor version used #.#.# (rpm version) -# (rpm release)-->
         <version>4.5.8-0</version>
         <packagemanager>zypper</packagemanager>
@@ -99,7 +111,7 @@ https://build.opensuse.org/package/show/openSUSE:Leap:15.3:Images/JeOS
         </type>
     </preferences>
 
-    <preferences profiles="Leap15.4.RaspberryPi4,Tumbleweed.RaspberryPi4">
+    <preferences profiles="Leap15.4.RaspberryPi4,Leap15.5.RaspberryPi4,Tumbleweed.RaspberryPi4">
         <!--Change to reflect the Rockstor version used #.#.# (rpm version) -# (rpm release)-->
         <version>4.5.8-0</version>
         <packagemanager>zypper</packagemanager>
@@ -150,7 +162,7 @@ https://build.opensuse.org/package/show/openSUSE:Leap:15.3:Images/JeOS
             </oemconfig>
         </type>
     </preferences>
-    <preferences profiles="Leap15.4.ARM64EFI,Tumbleweed.ARM64EFI">
+    <preferences profiles="Leap15.4.ARM64EFI,Leap15.5.ARM64EFI,Tumbleweed.ARM64EFI">
         <!--Change to reflect the Rockstor version used #.#.# (rpm version) -# (rpm release)-->
         <version>4.5.8-0</version>
         <packagemanager>zypper</packagemanager>
@@ -229,6 +241,10 @@ https://build.opensuse.org/package/show/openSUSE:Leap:15.3:Images/JeOS
                 profiles="Leap15.4.x86_64,Leap15.4.RaspberryPi4,Leap15.4.ARM64EFI">
         <source path="obs://openSUSE:Leap:15.4/standard"/>
     </repository>
+    <repository type="rpm-md" alias="Leap_15_5" imageinclude="true"
+                profiles="Leap15.5.x86_64,Leap15.5.RaspberryPi4,Leap15.5.ARM64EFI">
+        <source path="obs://openSUSE:Leap:15.5/standard"/>
+    </repository>
     <repository type="rpm-md" alias="Tumbleweed" imageinclude="true"
                 profiles="Tumbleweed.x86_64">
         <source path="obs://openSUSE:Tumbleweed/standard"/>
@@ -242,6 +258,10 @@ https://build.opensuse.org/package/show/openSUSE:Leap:15.3:Images/JeOS
                 profiles="Leap15.4.x86_64,Leap15.4.RaspberryPi4,Leap15.4.ARM64EFI">
         <source path="https://download.opensuse.org/update/leap/15.4/oss/"/>
     </repository>
+    <repository type="rpm-md" alias="Leap_15_5_Updates" imageinclude="true"
+                profiles="Leap15.5.x86_64,Leap15.5.RaspberryPi4,Leap15.5.ARM64EFI">
+        <source path="https://download.opensuse.org/update/leap/15.5/oss/"/>
+    </repository>
     <repository type="rpm-md" alias="Tumbleweed_Updates" imageinclude="true"
                 profiles="Tumbleweed.x86_64">
         <source path="https://download.opensuse.org/update/tumbleweed/"/>
@@ -250,18 +270,38 @@ https://build.opensuse.org/package/show/openSUSE:Leap:15.3:Images/JeOS
     <!-- or "openSUSE_Backports_SLE-15-SP3_Update" / "Online updates for openSUSE:Backports:SLE-15-SP3 (standard)" -->
     <!-- Alias repo-sle-update Name="Update repository with updates from SUSE Linux Enterprise 15" -->
     <!-- or "openSUSE_Leap_15.3_SLE-Update" / "Online updates for openSUSE Leap 15.3 (SLE)" -->
-    <!-- See: https://doc.opensuse.org/release-notes/x86_64/openSUSE/Leap/15.3/#installation-new-update-repos -->
-    <!-- Leap 15.3 profiles only - repos are multi architecture -->
+        <!-- See: https://doc.opensuse.org/release-notes/x86_64/openSUSE/Leap/15.3/#installation-new-update-repos -->
+    <!-- Leap 15.3+ profiles only - repos are multi architecture -->
     <!-- Not included in image as auto added by installed system. -->
     <!-- Used during image build to capture updates at time of installer build -->
     <repository type="rpm-md" alias="repo-backports-update"
                 profiles="Leap15.4.x86_64,Leap15.4.RaspberryPi4,Leap15.4.ARM64EFI">
         <source path="https://download.opensuse.org/update/leap/15.4/backports/"/>
     </repository>
+    <repository type="rpm-md" alias="repo-backports-update"
+                profiles="Leap15.5.x86_64,Leap15.5.RaspberryPi4,Leap15.5.ARM64EFI">
+        <source path="https://download.opensuse.org/update/leap/15.5/backports/"/>
+    </repository>
     <repository type="rpm-md" alias="repo-sle-update"
                 profiles="Leap15.4.x86_64,Leap15.4.RaspberryPi4,Leap15.4.ARM64EFI">
         <source path="https://download.opensuse.org/update/leap/15.4/sle/"/>
     </repository>
+    <repository type="rpm-md" alias="repo-sle-update"
+                profiles="Leap15.5.x86_64,Leap15.5.RaspberryPi4,Leap15.5.ARM64EFI">
+        <source path="https://download.opensuse.org/update/leap/15.5/sle/"/>
+    </repository>
+    <!-- open H264 repos: -->
+    <!-- https://news.opensuse.org/2023/01/24/opensuse-simplifies-codec-install/-->
+    <!-- https://codecs.opensuse.org/openh264/-->
+    <repository type="rpm-md" alias="repo-openh264" imageinclude="true"
+                profiles="Leap15.5.x86_64,Leap15.5.RaspberryPi4,Leap15.5.ARM64EFI">
+        <source path="http://codecs.opensuse.org/openh264/openSUSE_Leap"/>
+    </repository>
+    <repository type="rpm-md" alias="repo-openh264" imageinclude="true"
+                profiles="Tumbleweed.x86_64,Tumbleweed.RaspberryPi4,Tumbleweed.ARM64EFI">
+        <source path="http://codecs.opensuse.org/openh264/openSUSE_Tumbleweed"/>
+    </repository>
+
     <!-- https://osinside.github.io/kiwi/working_with_kiwi/xml_description.html#adding-repositories -->
     <!-- Local-Repository on build host: for pre-installed rockstor package -->
     <!--    <repository type="rpm-dir" alias="Local-Repository">-->
@@ -272,6 +312,10 @@ https://build.opensuse.org/package/show/openSUSE:Leap:15.3:Images/JeOS
     <repository type="rpm-md" alias="Rockstor-Testing"
                 profiles="Leap15.4.x86_64,Leap15.4.RaspberryPi4,Leap15.4.ARM64EFI">
         <source path="http://updates.rockstor.com:8999/rockstor-testing/leap/15.4/"/>
+    </repository>
+    <repository type="rpm-md" alias="Rockstor-Testing"
+                profiles="Leap15.5.x86_64,Leap15.5.RaspberryPi4,Leap15.5.ARM64EFI">
+        <source path="http://updates.rockstor.com:8999/rockstor-testing/leap/15.5/"/>
     </repository>
     <repository type="rpm-md" alias="Rockstor-Testing"
                 profiles="Tumbleweed.x86_64,Tumbleweed.RaspberryPi4,Tumbleweed.ARM64EFI">
@@ -289,6 +333,10 @@ https://build.opensuse.org/package/show/openSUSE:Leap:15.3:Images/JeOS
         <source path="https://download.opensuse.org/repositories/home:/rockstor/15.4/"/>
     </repository>
     <repository type="rpm-md" alias="home_rockstor" priority="105" imageinclude="true"
+                profiles="Leap15.5.x86_64,Leap15.5.RaspberryPi4,Leap15.5.ARM64EFI">
+        <source path="https://download.opensuse.org/repositories/home:/rockstor/15.5/"/>
+    </repository>
+    <repository type="rpm-md" alias="home_rockstor" priority="105" imageinclude="true"
                 profiles="Tumbleweed.x86_64,Tumbleweed.RaspberryPi4,Tumbleweed.ARM64EFI">
         <source path="https://download.opensuse.org/repositories/home:/rockstor/openSUSE_Tumbleweed/"/>
     </repository>
@@ -299,6 +347,10 @@ https://build.opensuse.org/package/show/openSUSE:Leap:15.3:Images/JeOS
     <repository type="rpm-md" alias="home_rockstor_branches_Base_System" priority="97" imageinclude="true"
                 profiles="Leap15.4.x86_64,Leap15.4.RaspberryPi4,Leap15.4.ARM64EFI">
         <source path="https://download.opensuse.org/repositories/home:/rockstor:/branches:/Base:/System/15.4/"/>
+    </repository>
+    <repository type="rpm-md" alias="home_rockstor_branches_Base_System" priority="97" imageinclude="true"
+                profiles="Leap15.5.x86_64,Leap15.5.RaspberryPi4,Leap15.5.ARM64EFI">
+        <source path="https://download.opensuse.org/repositories/home:/rockstor:/branches:/Base:/System/15.5/"/>
     </repository>
     <repository type="rpm-md" alias="home_rockstor_branches_Base_System" priority="97" imageinclude="true"
                 profiles="Tumbleweed.x86_64,Tumbleweed.RaspberryPi4,Tumbleweed.ARM64EFI">
@@ -313,21 +365,21 @@ https://build.opensuse.org/package/show/openSUSE:Leap:15.3:Images/JeOS
     <!-- Kernel HEAD Backports -->
     <!-- https://build.opensuse.org/repositories/Kernel:HEAD:Backport -->
     <!--    <repository type="rpm-md" alias="Kernel_HEAD_Backport" imageinclude="true"-->
-    <!--                profiles="Leap15.4.x86_64,Leap15.4.RaspberryPi4,Leap15.4.ARM64EFI">-->
+    <!--                profiles="Leap15.5.x86_64,Leap15.5.RaspberryPi4,Leap15.5.ARM64EFI">-->
     <!--        <source path="https://download.opensuse.org/repositories/Kernel:/HEAD:/Backport/standard/"/>-->
     <!--    </repository>-->
     <!-- Kernel Stable Backports -->
     <!-- https://build.opensuse.org/project/show/Kernel:stable:Backport -->
     <!-- See also: https://rockstor.com/docs/howtos/stable_kernel_backport.html  -->
     <!--    <repository type="rpm-md" alias="Kernel_stable_Backport" imageinclude="true"-->
-    <!--                profiles="Leap15.4.x86_64,Leap15.4.RaspberryPi4,Leap15.4.ARM64EFI">-->
+    <!--                profiles="Leap15.5.x86_64,Leap15.5.RaspberryPi4,Leap15.5.ARM64EFI">-->
     <!--        <source path="https://download.opensuse.org/repositories/Kernel:/stable:/Backport/standard/"/>-->
     <!--    </repository>-->
     <!-- btrfs-progs backport via filesystems repo -->
     <!-- https://build.opensuse.org/project/show/filesystems -->
     <!--    <repository type="rpm-md" alias="filesystems" imageinclude="true"-->
-    <!--                profiles="Leap15.4.x86_64,Leap15.4.RaspberryPi4,Leap15.4.ARM64EFI">-->
-    <!--        <source path="https://download.opensuse.org/repositories/filesystems/15.4/"/>-->
+    <!--                profiles="Leap15.5.x86_64,Leap15.5.RaspberryPi4,Leap15.5.ARM64EFI">-->
+    <!--        <source path="https://download.opensuse.org/repositories/filesystems/15.5/"/>-->
     <!--    </repository>-->
     <packages type="image">
         <package name="adaptec-firmware"/>  <!--Razor AIC94xx Series SAS-->
@@ -402,7 +454,7 @@ https://build.opensuse.org/package/show/openSUSE:Leap:15.3:Images/JeOS
         <!--Change to reflect the version specified, i.e. 4.5.8-0-->
         <package name="rockstor-4.5.8-0"/>
     </packages>
-    <packages type="image" profiles="Leap15.4.RaspberryPi4,Tumbleweed.RaspberryPi4">
+    <packages type="image" profiles="Leap15.4.RaspberryPi4,Leap15.5.RaspberryPi4,Tumbleweed.RaspberryPi4">
         <package name="raspberrypi-eeprom" arch="aarch64"/>
         <package name="raspberrypi-firmware" arch="aarch64"/>
         <package name="raspberrypi-firmware-config" arch="aarch64"/>


### PR DESCRIPTION
Fixes #146 

Creating as draft pull-request for now to enable proper testing.

Add profiles to build installers based on Leap 15.5 for all our targets:

  - x86_64
  - RaspberryPi4
  - ARM64_EFI

Update README.MD to set these Leap 15.5 profiles as default in all examples given.

Includes correction of minor typos.