### PR TITLE
149 full disk luks encrpytion option for Installer

### DIFF
--- a/README.md
+++ b/README.md
@@ -151,6 +151,10 @@ No edit is required if you wish to use the generic installer filename and defaul
 To change these defaults edit all lines directly preceded by **<!--Change to ...** as per the **...** details given.
 Our release infrastructure performs these same edits to set official installer filenames and rockstor package versions.
 
+If you want to enable LUKS encryption of the Root disk (where Rockstor is installed), uncomment the relevant parameters
+that are available in the **Leap15.5.x86_64** profile which are preceded by relevant comments. This will enable `luks2` encryption
+and utilize PBKDF2, as grub does not yet support the more recent `argon2id` algorithm.
+
 ### Leap15.5.x86_64 profile
 Executed, as the root user, in the directory containing this repository's `rockstor.kiwi` file.
 ```shell

--- a/README.md
+++ b/README.md
@@ -155,6 +155,9 @@ If you want to enable LUKS encryption of the Root disk (where Rockstor is instal
 that are available in the **Leap15.5.x86_64** profile which are preceded by relevant comments. This will enable `luks2` encryption
 and utilize PBKDF2, as grub does not yet support the more recent `argon2id` algorithm.
 
+N.B.: The `luksformat` parameter's preceding hyphens have to be escaped so they can be held as as a comment. When adding more non-commented
+parameters, the required double-hyphens can be inserted without escaping them to their Unicode character codes.
+
 ### Leap15.5.x86_64 profile
 Executed, as the root user, in the directory containing this repository's `rockstor.kiwi` file.
 ```shell

--- a/rockstor.kiwi
+++ b/rockstor.kiwi
@@ -73,6 +73,11 @@ https://build.opensuse.org/package/show/openSUSE:Leap:15.5:Images/JeOS
         <!--bootpartition= is redundant post kiwi issue #1351-->
         <!--firmware="efi" See https://github.com/OSInside/kiwi/issues/1428 re AArch64-->
         <!--Re AArch64: https://github.com/OSInside/kiwi/issues/1491-->
+        <!-- For root disk LUKS encryption (using luks2 & PBKDF2 instead of argon2id) -->
+        <!-- add below 2 luks attributes below the 'efipartsize' entry in the type definition-->
+        <!-- note: change luks Pass Phrase -->
+        <!--        luks="c00l_Pa$$Phra$e" -->
+        <!--        luks_version="luks2" -->
         <type
                 image="oem"
                 primary="true"
@@ -88,18 +93,12 @@ https://build.opensuse.org/package/show/openSUSE:Leap:15.5:Images/JeOS
                 btrfs_root_is_snapshot="true"
                 btrfs_quota_groups="false"
                 efipartsize="64"
-                <!-- For root disk LUKS encryption (using luks2 & PBKDF2 instead of argon2id -->
-                <!-- uncomment below entries -->
-                <!-- note: change Pass Phrase -->
-                <!-- luks="c00l_Pa$$Phra$e" -->
-                <!-- luks_version="luks2" -->
         >
-            <!-- For full disk LUKS encryption uncomment below entries -->
-            <!-- PBKDF2 is required for grub to recognize encryption -->
-            <!-- add any other command line LUKS options if deviating from defaults -->
-            <!-- <luksformat> -->
-                <!-- <option name="--pbkdf" value="PBKDF2"/> -->
-            <!-- </luksformat> -->
+        <!-- For full disk LUKS encryption uncomment below entries -->
+        <!-- PBKDF2 is required for grub to recognize encryption -->
+            <luksformat>
+                <option name="&#45;&#45;pbkdf" value="PBKDF2"/>
+            </luksformat>
             <systemdisk>
                 <volume name="home"/>
                 <volume name="root"/>

--- a/rockstor.kiwi
+++ b/rockstor.kiwi
@@ -88,8 +88,19 @@ https://build.opensuse.org/package/show/openSUSE:Leap:15.5:Images/JeOS
                 btrfs_root_is_snapshot="true"
                 btrfs_quota_groups="false"
                 efipartsize="64"
+				<!-- For root disk LUKS encryption (using luks2 & PBKDF2 instead of argon2id -->
+				<!-- uncomment below entries -->
+				<!-- note: change Pass Phrase -->
+				<!-- luks="c00l_Pa$$Phra$e" -->
+				<!-- luks_version="luks2" -->
         >
-            <systemdisk>
+            <!-- For full disk LUKS encryption uncomment below entries -->
+			<!-- PBKDF2 is required for grub to recognize encryption -->
+			<!-- add any other command line LUKS options if deviating from defaults -->
+			<!-- <luksformat> -->
+                <!-- <option name="--pbkdf" value="PBKDF2"/> -->
+            <!-- </luksformat> -->
+			<systemdisk>
                 <volume name="home"/>
                 <volume name="root"/>
                 <volume name="tmp"/>

--- a/rockstor.kiwi
+++ b/rockstor.kiwi
@@ -88,19 +88,19 @@ https://build.opensuse.org/package/show/openSUSE:Leap:15.5:Images/JeOS
                 btrfs_root_is_snapshot="true"
                 btrfs_quota_groups="false"
                 efipartsize="64"
-				<!-- For root disk LUKS encryption (using luks2 & PBKDF2 instead of argon2id -->
-				<!-- uncomment below entries -->
-				<!-- note: change Pass Phrase -->
-				<!-- luks="c00l_Pa$$Phra$e" -->
-				<!-- luks_version="luks2" -->
+                <!-- For root disk LUKS encryption (using luks2 & PBKDF2 instead of argon2id -->
+                <!-- uncomment below entries -->
+                <!-- note: change Pass Phrase -->
+                <!-- luks="c00l_Pa$$Phra$e" -->
+                <!-- luks_version="luks2" -->
         >
             <!-- For full disk LUKS encryption uncomment below entries -->
-			<!-- PBKDF2 is required for grub to recognize encryption -->
-			<!-- add any other command line LUKS options if deviating from defaults -->
-			<!-- <luksformat> -->
+            <!-- PBKDF2 is required for grub to recognize encryption -->
+            <!-- add any other command line LUKS options if deviating from defaults -->
+            <!-- <luksformat> -->
                 <!-- <option name="--pbkdf" value="PBKDF2"/> -->
             <!-- </luksformat> -->
-			<systemdisk>
+            <systemdisk>
                 <volume name="home"/>
                 <volume name="root"/>
                 <volume name="tmp"/>

--- a/rockstor.kiwi
+++ b/rockstor.kiwi
@@ -96,9 +96,9 @@ https://build.opensuse.org/package/show/openSUSE:Leap:15.5:Images/JeOS
         >
         <!-- For full disk LUKS encryption uncomment below entries -->
         <!-- PBKDF2 is required for grub to recognize encryption -->
-            <luksformat>
-                <option name="&#45;&#45;pbkdf" value="PBKDF2"/>
-            </luksformat>
+        <!--    <luksformat> -->
+        <!--        <option name="&#45;&#45;pbkdf" value="PBKDF2"/> -->
+        <!--    </luksformat> -->
             <systemdisk>
                 <volume name="home"/>
                 <volume name="root"/>


### PR DESCRIPTION
Fixes #149.
- Adding optional (commented) parameters for Rockstor OS disk LUKS encryption to LEAP 15.5 profile.
- Adding section to Readme highlighting above installer option for the roll-your-own crowd