### PR TITLE
Tumbleweed build failures on all profiles #152

### DIFF
--- a/_multibuild
+++ b/_multibuild
@@ -1,4 +1,5 @@
 <multibuild>
-  <flavor>Leap15.3.x86_64</flavor>
-  <flavor>Leap15.3.RaspberryPi4</flavor>
+  <flavor>Leap15.5.x86_64</flavor>
+  <flavor>Leap15.5.RaspberryPi4</flavor>
+  <flavor>Leap15.5.ARM64EFI</flavor>
 </multibuild>

--- a/rockstor.kiwi
+++ b/rockstor.kiwi
@@ -400,7 +400,7 @@ https://build.opensuse.org/package/show/openSUSE:Leap:15.5:Images/JeOS
         <package name="fontconfig"/>
         <package name="fonts-config"/>
         <package name="gfxboot-branding-upstream" arch="x86_64"/> <!-- grub bg -->
-        <package name="gio-branding-upstream"/> <!--or branding-openSUSE-->
+        <!-- <package name="gio-branding-upstream"/> <!-- breaks in TW re gio-branding-openSUSE--> -->
         <package name="group(mail)"/>
         <package name="group(wheel)"/>
         <package name="grub2"/>

--- a/rockstor.kiwi
+++ b/rockstor.kiwi
@@ -477,6 +477,7 @@ https://build.opensuse.org/package/show/openSUSE:Leap:15.5:Images/JeOS
         <package name="glibc-locale"/>  <!-- possbily glibc-locale-base-->
         <package name="grep"/>
         <package name="gzip"/>
+        <package name="diffutils"/>
         <package name="openSUSE-release"/>  <!-- /etc/os-release etc -->
         <package name="udev"/>
         <package name="xz"/>

--- a/rockstor.kiwi
+++ b/rockstor.kiwi
@@ -400,7 +400,8 @@ https://build.opensuse.org/package/show/openSUSE:Leap:15.5:Images/JeOS
         <package name="fontconfig"/>
         <package name="fonts-config"/>
         <package name="gfxboot-branding-upstream" arch="x86_64"/> <!-- grub bg -->
-        <!-- <package name="gio-branding-upstream"/> <!-- breaks in TW re gio-branding-openSUSE--> -->
+        <!-- gio-branding-upstream breaks in TW re gio-branding-openSUSE -->
+        <!-- <package name="gio-branding-upstream"/> -->
         <package name="group(mail)"/>
         <package name="group(wheel)"/>
         <package name="grub2"/>


### PR DESCRIPTION
Remove to-be-redundant gio-branding-upstream to avoid current build failure for all Tumbleweed profiles, and prepare for likely related changes re ALP.

Thought to be invoked only by glib-devel dependency in rockstor package which in turn is thought to be from the to-be-replaced python-dbus use.

Includes incidental _multibuild profile updates.

Relates to #152