### PR TITLE
Update schema version to 8.1 and modernise formatting #169

### DIFF
--- a/rockstor.kiwi
+++ b/rockstor.kiwi
@@ -1,58 +1,36 @@
+<?xml version="1.0" encoding="utf-8"?>
 <!-- We are an OEM image for install media CD/DVD or flash disk -->
 <!-- Schema doc available at: -->
-<!-- https://osinside.github.io/kiwi/development/schema.html#schema-docs -->
+<!-- https://osinside.github.io/kiwi/image_description.html -->
 <!-- For reference see: -->
 <!-- https://en.opensuse.org/Portal:JeOS -->
 <!-- https://documentation.suse.com/kiwi/9/single-html/kiwi/index.html -->
 <!-- https://build.opensuse.org/package/show/openSUSE:Leap:15.5/kiwi-templates-Minimal -->
 <!-- https://build.opensuse.org/package/show/openSUSE:Leap:15.5:Images/kiwi-templates-Minimal -->
 <!-- https://build.opensuse.org/package/show/openSUSE:Leap:15.5:Images/JeOS -->
-
 <!-- OBS-Profiles: @BUILD_FLAVOR@ -->
-
-<image schemaversion="7.1" name="Rockstor-NAS">
-
+<image schemaversion="8.1" name="Rockstor-NAS">
     <description type="system">
-        <author>Philip Guyton</author>
-        <contact>philip@yewtreeapps.com</contact>
+        <author>The Rockstor Project</author>
+        <contact>support@rockstor.com</contact>
         <specification>
             Rockstor install image based on openSUSE
         </specification>
     </description>
-
     <profiles>
         <!-- For preferences, drivers, repository, packages, and users elements -->
-        <!-- https://osinside.github.io/kiwi/working_with_kiwi/xml_description.html#image-profiles -->
+        <!-- https://osinside.github.io/kiwi/working_with_images/build_with_profiles.html -->
         <!-- N.B. can inherit one profile within another via requires profile="" -->
-        <profile name="Leap15.5.x86_64"
-                 description="Rockstor built on openSUSE Leap 15.5 x86_64"
-                 arch="x86_64"/>
-        <profile name="Leap15.5.RaspberryPi4"
-                 description="Rockstor built on openSUSE Leap 15.5 Raspberry_Pi"
-                 arch="aarch64"/>
-        <profile name="Leap15.5.ARM64EFI"
-                 description="Rockstor built on openSUSE Leap 15.5 ARM64 EFI/VM/Ten64"
-                 arch="aarch64"/>
-        <profile name="Leap15.6.x86_64"
-                 description="Rockstor built on openSUSE Leap 15.6 x86_64"
-                 arch="x86_64"/>
-        <profile name="Leap15.6.RaspberryPi4"
-                 description="Rockstor built on openSUSE Leap 15.6 Raspberry_Pi"
-                 arch="aarch64"/>
-        <profile name="Leap15.6.ARM64EFI"
-                 description="Rockstor built on openSUSE Leap 15.6 ARM64 EFI/VM/Ten64"
-                 arch="aarch64"/>
-        <profile name="Tumbleweed.x86_64"
-                 description="Rockstor built on openSUSE Tumbleweed x86_64"
-                 arch="x86_64"/>
-        <profile name="Tumbleweed.RaspberryPi4"
-                 description="Rockstor built on openSUSE Tumbleweed Raspberry_Pi"
-                 arch="aarch64"/>
-        <profile name="Tumbleweed.ARM64EFI"
-                 description="Rockstor built on openSUSE Tumbleweed ARM64 EFI/VM/Ten64"
-                 arch="aarch64"/>
+        <profile name="Leap15.5.x86_64" description="Rockstor built on openSUSE Leap 15.5 x86_64" arch="x86_64"/>
+        <profile name="Leap15.5.RaspberryPi4" description="Rockstor built on openSUSE Leap 15.5 Raspberry_Pi" arch="aarch64"/>
+        <profile name="Leap15.5.ARM64EFI" description="Rockstor built on openSUSE Leap 15.5 ARM64 EFI/VM/Ten64" arch="aarch64"/>
+        <profile name="Leap15.6.x86_64" description="Rockstor built on openSUSE Leap 15.6 x86_64" arch="x86_64"/>
+        <profile name="Leap15.6.RaspberryPi4" description="Rockstor built on openSUSE Leap 15.6 Raspberry_Pi" arch="aarch64"/>
+        <profile name="Leap15.6.ARM64EFI" description="Rockstor built on openSUSE Leap 15.6 ARM64 EFI/VM/Ten64" arch="aarch64"/>
+        <profile name="Tumbleweed.x86_64" description="Rockstor built on openSUSE Tumbleweed x86_64" arch="x86_64"/>
+        <profile name="Tumbleweed.RaspberryPi4" description="Rockstor built on openSUSE Tumbleweed Raspberry_Pi" arch="aarch64"/>
+        <profile name="Tumbleweed.ARM64EFI" description="Rockstor built on openSUSE Tumbleweed ARM64 EFI/VM/Ten64" arch="aarch64"/>
     </profiles>
-
     <preferences profiles="Leap15.5.x86_64,Leap15.6.x86_64,Tumbleweed.x86_64">
         <version>5.0.9-0</version>
         <packagemanager>zypper</packagemanager>
@@ -70,27 +48,13 @@
         <!-- note: change luks Pass Phrase -->
         <!--        luks="c00l_Pa$$Phra$e" -->
         <!--        luks_version="luks2" -->
-        <type
-                image="oem"
-                primary="true"
-                initrd_system="dracut"
-                filesystem="btrfs"
-                fsmountoptions="noatime"
-                firmware="efi"
-                installiso="true"
-                kernelcmdline="nomodeset plymouth.enable=0 rd.kiwi.oem.maxdisk=5000G"
-                bootpartition="false"
-                devicepersistency="by-label"
-                btrfs_root_is_snapshot="true"
-                btrfs_quota_groups="false"
-                efipartsize="64"
-        >
+        <type image="oem" primary="true" initrd_system="dracut" filesystem="btrfs" fsmountoptions="noatime" firmware="efi" installiso="true" kernelcmdline="nomodeset plymouth.enable=0 rd.kiwi.oem.maxdisk=5000G" bootpartition="false" devicepersistency="by-label" btrfs_root_is_snapshot="true" btrfs_quota_groups="false" efipartsize="64">
             <bootloader name="grub2"/>
-        <!-- For full disk LUKS encryption uncomment below entries -->
-        <!-- PBKDF2 is required for grub to recognize encryption -->
-        <!--    <luksformat> -->
-        <!--        <option name="&#45;&#45;pbkdf" value="PBKDF2"/> -->
-        <!--    </luksformat> -->
+            <!-- For full disk LUKS encryption uncomment below entries -->
+            <!-- PBKDF2 is required for grub to recognize encryption -->
+            <!--    <luksformat> -->
+            <!--        <option name="&#45;&#45;pbkdf" value="PBKDF2"/> -->
+            <!--    </luksformat> -->
             <systemdisk>
                 <volume name="home"/>
                 <volume name="root"/>
@@ -98,8 +62,7 @@
                 <volume name="opt"/>
                 <volume name="srv"/>
                 <volume name="boot/grub2/i386-pc"/>
-                <volume name="boot/grub2/x86_64-efi"
-                        mountpoint="boot/grub2/x86_64-efi"/>
+                <volume name="boot/grub2/x86_64-efi" mountpoint="boot/grub2/x86_64-efi"/>
                 <volume name="usr/local"/>
                 <volume name="var" copy_on_write="false"/>
             </systemdisk>
@@ -112,7 +75,6 @@
             </oemconfig>
         </type>
     </preferences>
-
     <preferences profiles="Leap15.5.RaspberryPi4,Leap15.6.RaspberryPi4,Tumbleweed.RaspberryPi4">
         <version>5.0.9-0</version>
         <packagemanager>zypper</packagemanager>
@@ -125,20 +87,7 @@
         <bootloader-theme>upstream</bootloader-theme>
         <!-- firmware="efi" See https://github.com/OSInside/kiwi/issues/1428 re AArch64 -->
         <!-- Re AArch64: https://github.com/OSInside/kiwi/issues/1491 -->
-        <type
-                image="oem"
-                initrd_system="dracut"
-                filesystem="btrfs"
-                fsmountoptions="noatime,compress=lzo"
-                firmware="efi"
-                kernelcmdline="plymouth.enable=0 rd.kiwi.oem.maxdisk=5000G console=ttyS0,115200 console=tty"
-                bootpartition="false"
-                devicepersistency="by-uuid"
-                btrfs_root_is_snapshot="true"
-                btrfs_quota_groups="false"
-                efipartsize="64"
-                editbootinstall="editbootinstall_rpi.sh"
-        >
+        <type image="oem" initrd_system="dracut" filesystem="btrfs" fsmountoptions="noatime,compress=lzo" firmware="efi" kernelcmdline="plymouth.enable=0 rd.kiwi.oem.maxdisk=5000G console=ttyS0,115200 console=tty" bootpartition="false" devicepersistency="by-uuid" btrfs_root_is_snapshot="true" btrfs_quota_groups="false" efipartsize="64" editbootinstall="editbootinstall_rpi.sh">
             <bootloader name="grub2"/>
             <systemdisk>
                 <volume name="home"/>
@@ -146,8 +95,7 @@
                 <volume name="tmp"/>
                 <volume name="opt"/>
                 <volume name="srv"/>
-                <volume name="boot/grub2/arm64-efi"
-                        mountpoint="boot/grub2/arm64-efi"/>
+                <volume name="boot/grub2/arm64-efi" mountpoint="boot/grub2/arm64-efi"/>
                 <volume name="usr/local"/>
                 <volume name="var" copy_on_write="false"/>
             </systemdisk>
@@ -158,7 +106,6 @@
             </oemconfig>
         </type>
     </preferences>
-
     <preferences profiles="Leap15.5.ARM64EFI,Leap15.6.ARM64EFI,Tumbleweed.ARM64EFI">
         <version>5.0.9-0</version>
         <packagemanager>zypper</packagemanager>
@@ -171,20 +118,7 @@
         <bootloader-theme>upstream</bootloader-theme>
         <!-- firmware="efi" See https://github.com/OSInside/kiwi/issues/1428 re AArch64 -->
         <!-- Re AArch64: https://github.com/OSInside/kiwi/issues/1491 -->
-        <type
-                image="oem"
-                initrd_system="dracut"
-                filesystem="btrfs"
-                fsmountoptions="noatime,compress=lzo"
-                firmware="efi"
-                kernelcmdline="plymouth.enable=0 rd.kiwi.oem.maxdisk=5000G earlycon"
-                bootpartition="false"
-                devicepersistency="by-uuid"
-                btrfs_root_is_snapshot="true"
-                btrfs_quota_groups="false"
-                efipartsize="64"
-                format="qcow2"
-        >
+        <type image="oem" initrd_system="dracut" filesystem="btrfs" fsmountoptions="noatime,compress=lzo" firmware="efi" kernelcmdline="plymouth.enable=0 rd.kiwi.oem.maxdisk=5000G earlycon" bootpartition="false" devicepersistency="by-uuid" btrfs_root_is_snapshot="true" btrfs_quota_groups="false" efipartsize="64" format="qcow2">
             <bootloader name="grub2"/>
             <systemdisk>
                 <volume name="home"/>
@@ -192,8 +126,7 @@
                 <volume name="tmp"/>
                 <volume name="opt"/>
                 <volume name="srv"/>
-                <volume name="boot/grub2/arm64-efi"
-                        mountpoint="boot/grub2/arm64-efi"/>
+                <volume name="boot/grub2/arm64-efi" mountpoint="boot/grub2/arm64-efi"/>
                 <volume name="usr/local"/>
                 <volume name="var" copy_on_write="false"/>
             </systemdisk>
@@ -205,55 +138,38 @@
             </oemconfig>
         </type>
     </preferences>
-
     <users>
-        <user password="$1$wYJUgpM5$RXMMeASDc035eX.NbYWFl0" home="/root"
-              name="root" groups="root"/>
+        <user password="$1$wYJUgpM5$RXMMeASDc035eX.NbYWFl0" home="/root" name="root" groups="root"/>
     </users>
-
     <!-- For zypper priority 1 is highest, priority 0 returns to default of 99 -->
     <!-- https://build.opensuse.org/project/show/Virtualization:Appliances:Builder -->
-
-    <repository type="rpm-md" alias="kiwi" priority="1"
-                profiles="Tumbleweed.x86_64,Tumbleweed.RaspberryPi4,Tumbleweed.ARM64EFI">
+    <repository type="rpm-md" alias="kiwi" priority="1" profiles="Tumbleweed.x86_64,Tumbleweed.RaspberryPi4,Tumbleweed.ARM64EFI">
         <source path="obs://Virtualization:Appliances:Builder/openSUSE_Tumbleweed"/>
     </repository>
-
     <!-- https://en.opensuse.org/Package_repositories -->
     <!-- Alias repo-oss Name="Main Repository" in JeOS -->
-
-    <repository type="rpm-md" alias="Leap_15_5" imageinclude="true"
-                profiles="Leap15.5.x86_64,Leap15.5.RaspberryPi4,Leap15.5.ARM64EFI">
+    <repository type="rpm-md" alias="Leap_15_5" imageinclude="true" profiles="Leap15.5.x86_64,Leap15.5.RaspberryPi4,Leap15.5.ARM64EFI">
         <source path="obs://openSUSE:Leap:15.5/standard"/>
     </repository>
-    <repository type="rpm-md" alias="Leap_15_6" imageinclude="true"
-                profiles="Leap15.6.x86_64,Leap15.6.RaspberryPi4,Leap15.6.ARM64EFI">
+    <repository type="rpm-md" alias="Leap_15_6" imageinclude="true" profiles="Leap15.6.x86_64,Leap15.6.RaspberryPi4,Leap15.6.ARM64EFI">
         <source path="obs://openSUSE:Leap:15.6/standard"/>
     </repository>
-    <repository type="rpm-md" alias="Tumbleweed" imageinclude="true"
-                profiles="Tumbleweed.x86_64">
+    <repository type="rpm-md" alias="Tumbleweed" imageinclude="true" profiles="Tumbleweed.x86_64">
         <source path="obs://openSUSE:Tumbleweed/standard"/>
     </repository>
-    <repository type="rpm-md" alias="Tumbleweed" imageinclude="true"
-                profiles="Tumbleweed.RaspberryPi4,Tumbleweed.ARM64EFI">
+    <repository type="rpm-md" alias="Tumbleweed" imageinclude="true" profiles="Tumbleweed.RaspberryPi4,Tumbleweed.ARM64EFI">
         <source path="https://download.opensuse.org/ports/aarch64/tumbleweed/repo/oss/"/>
     </repository>
-
     <!-- Alias repo-update Name="Main Update Repository" or "openSUSE-Tumbleweed-Update" in JeOS -->
-
-    <repository type="rpm-md" alias="Leap_15_5_Updates" imageinclude="true"
-                profiles="Leap15.5.x86_64,Leap15.5.RaspberryPi4,Leap15.5.ARM64EFI">
+    <repository type="rpm-md" alias="Leap_15_5_Updates" imageinclude="true" profiles="Leap15.5.x86_64,Leap15.5.RaspberryPi4,Leap15.5.ARM64EFI">
         <source path="https://download.opensuse.org/update/leap/15.5/oss/"/>
     </repository>
-    <repository type="rpm-md" alias="Leap_15_6_Updates" imageinclude="true"
-                profiles="Leap15.6.x86_64,Leap15.6.RaspberryPi4,Leap15.6.ARM64EFI">
+    <repository type="rpm-md" alias="Leap_15_6_Updates" imageinclude="true" profiles="Leap15.6.x86_64,Leap15.6.RaspberryPi4,Leap15.6.ARM64EFI">
         <source path="https://download.opensuse.org/update/leap/15.6/oss/"/>
     </repository>
-    <repository type="rpm-md" alias="Tumbleweed_Updates" imageinclude="true"
-                profiles="Tumbleweed.x86_64">
+    <repository type="rpm-md" alias="Tumbleweed_Updates" imageinclude="true" profiles="Tumbleweed.x86_64">
         <source path="https://download.opensuse.org/update/tumbleweed/"/>
     </repository>
-
     <!-- Alias repo-backports-update Name="Update repository of openSUSE Backports" -->
     <!-- or "openSUSE_Backports_SLE-15-SP3_Update" / "Online updates for openSUSE:Backports:SLE-15-SP3 (standard)" -->
     <!-- Alias repo-sle-update Name="Update repository with updates from SUSE Linux Enterprise 15" -->
@@ -262,105 +178,68 @@
     <!-- Leap 15.3+ profiles only - repos are multi architecture -->
     <!-- Not included in image as auto added by installed system. -->
     <!-- Used during image build to capture updates at time of installer build -->
-
-    <repository type="rpm-md" alias="repo-backports-update"
-                profiles="Leap15.5.x86_64,Leap15.5.RaspberryPi4,Leap15.5.ARM64EFI">
+    <repository type="rpm-md" alias="repo-backports-update" profiles="Leap15.5.x86_64,Leap15.5.RaspberryPi4,Leap15.5.ARM64EFI">
         <source path="https://download.opensuse.org/update/leap/15.5/backports/"/>
     </repository>
-    <repository type="rpm-md" alias="repo-sle-update"
-                profiles="Leap15.5.x86_64,Leap15.5.RaspberryPi4,Leap15.5.ARM64EFI">
+    <repository type="rpm-md" alias="repo-sle-update" profiles="Leap15.5.x86_64,Leap15.5.RaspberryPi4,Leap15.5.ARM64EFI">
         <source path="https://download.opensuse.org/update/leap/15.5/sle/"/>
     </repository>
-    <repository type="rpm-md" alias="repo-backports-update"
-                profiles="Leap15.6.x86_64,Leap15.6.RaspberryPi4,Leap15.6.ARM64EFI">
+    <repository type="rpm-md" alias="repo-backports-update" profiles="Leap15.6.x86_64,Leap15.6.RaspberryPi4,Leap15.6.ARM64EFI">
         <source path="https://download.opensuse.org/update/leap/15.6/backports/"/>
     </repository>
-    <repository type="rpm-md" alias="repo-sle-update"
-                profiles="Leap15.6.x86_64,Leap15.6.RaspberryPi4,Leap15.6.ARM64EFI">
+    <repository type="rpm-md" alias="repo-sle-update" profiles="Leap15.6.x86_64,Leap15.6.RaspberryPi4,Leap15.6.ARM64EFI">
         <source path="https://download.opensuse.org/update/leap/15.6/sle/"/>
     </repository>
-
     <!-- open H264 repos: -->
     <!-- https://news.opensuse.org/2023/01/24/opensuse-simplifies-codec-install/ -->
     <!-- https://codecs.opensuse.org/openh264/ -->
-
-    <repository type="rpm-md" alias="repo-openh264" imageinclude="true"
-                profiles="Leap15.5.x86_64,Leap15.5.RaspberryPi4,Leap15.5.ARM64EFI">
+    <repository type="rpm-md" alias="repo-openh264" imageinclude="true" profiles="Leap15.5.x86_64,Leap15.5.RaspberryPi4,Leap15.5.ARM64EFI">
         <source path="http://codecs.opensuse.org/openh264/openSUSE_Leap"/>
     </repository>
-    <repository type="rpm-md" alias="repo-openh264" imageinclude="true"
-                profiles="Leap15.6.x86_64,Leap15.6.RaspberryPi4,Leap15.6.ARM64EFI">
+    <repository type="rpm-md" alias="repo-openh264" imageinclude="true" profiles="Leap15.6.x86_64,Leap15.6.RaspberryPi4,Leap15.6.ARM64EFI">
         <source path="http://codecs.opensuse.org/openh264/openSUSE_Leap"/>
     </repository>
-    <repository type="rpm-md" alias="repo-openh264" imageinclude="true"
-                profiles="Tumbleweed.x86_64,Tumbleweed.RaspberryPi4,Tumbleweed.ARM64EFI">
+    <repository type="rpm-md" alias="repo-openh264" imageinclude="true" profiles="Tumbleweed.x86_64,Tumbleweed.RaspberryPi4,Tumbleweed.ARM64EFI">
         <source path="http://codecs.opensuse.org/openh264/openSUSE_Tumbleweed"/>
     </repository>
-
     <!-- Tailscale repos: -->
     <!-- https://tailscale.com/kb/1303/install-opensuse-leap/ -->
     <!-- https://tailscale.com/kb/1047/install-opensuse-tumbleweed/ -->
-
-    <repository type="rpm-md" alias="tailscale-stable" imageinclude="true"
-                repository_gpgcheck="true" package_gpgcheck="false"
-                customize="add_tailscale_repo_gpgkey.sh"
-                profiles="Leap15.5.x86_64" >
+    <repository type="rpm-md" alias="tailscale-stable" imageinclude="true" repository_gpgcheck="true" package_gpgcheck="false" customize="add_tailscale_repo_gpgkey.sh" profiles="Leap15.5.x86_64">
         <source path="https://pkgs.tailscale.com/stable/opensuse/leap/15.5/x86_64"/>
     </repository>
-    <repository type="rpm-md" alias="tailscale-stable" imageinclude="true"
-                repository_gpgcheck="true" package_gpgcheck="false"
-                customize="add_tailscale_repo_gpgkey.sh"
-                profiles="Leap15.5.RaspberryPi4,Leap15.5.ARM64EFI">
+    <repository type="rpm-md" alias="tailscale-stable" imageinclude="true" repository_gpgcheck="true" package_gpgcheck="false" customize="add_tailscale_repo_gpgkey.sh" profiles="Leap15.5.RaspberryPi4,Leap15.5.ARM64EFI">
         <source path="https://pkgs.tailscale.com/stable/opensuse/leap/15.5/aarch64"/>
     </repository>
     <!-- TODO POST TAILSCALE LEAP 15.6 REPO AVAILABLE - TEMP USE OF 15.5 -->
-    <repository type="rpm-md" alias="tailscale-stable" imageinclude="true"
-                repository_gpgcheck="true" package_gpgcheck="false"
-                customize="add_tailscale_repo_gpgkey.sh"
-                profiles="Leap15.6.x86_64" >
+    <repository type="rpm-md" alias="tailscale-stable" imageinclude="true" repository_gpgcheck="true" package_gpgcheck="false" customize="add_tailscale_repo_gpgkey.sh" profiles="Leap15.6.x86_64">
         <source path="https://pkgs.tailscale.com/stable/opensuse/leap/15.5/x86_64"/>
     </repository>
-    <repository type="rpm-md" alias="tailscale-stable" imageinclude="true"
-                repository_gpgcheck="true" package_gpgcheck="false"
-                customize="add_tailscale_repo_gpgkey.sh"
-                profiles="Leap15.6.RaspberryPi4,Leap15.6.ARM64EFI">
+    <repository type="rpm-md" alias="tailscale-stable" imageinclude="true" repository_gpgcheck="true" package_gpgcheck="false" customize="add_tailscale_repo_gpgkey.sh" profiles="Leap15.6.RaspberryPi4,Leap15.6.ARM64EFI">
         <source path="https://pkgs.tailscale.com/stable/opensuse/leap/15.5/aarch64"/>
     </repository>
-    <repository type="rpm-md" alias="tailscale-stable" imageinclude="true"
-                repository_gpgcheck="true" package_gpgcheck="false"
-                customize="add_tailscale_repo_gpgkey.sh"
-                profiles="Tumbleweed.x86_64">
+    <repository type="rpm-md" alias="tailscale-stable" imageinclude="true" repository_gpgcheck="true" package_gpgcheck="false" customize="add_tailscale_repo_gpgkey.sh" profiles="Tumbleweed.x86_64">
         <source path="https://pkgs.tailscale.com/stable/opensuse/tumbleweed/x86_64"/>
     </repository>
-    <repository type="rpm-md" alias="tailscale-stable" imageinclude="true"
-                repository_gpgcheck="true" package_gpgcheck="false"
-                customize="add_tailscale_repo_gpgkey.sh"
-                profiles="Tumbleweed.RaspberryPi4,Tumbleweed.ARM64EFI">
+    <repository type="rpm-md" alias="tailscale-stable" imageinclude="true" repository_gpgcheck="true" package_gpgcheck="false" customize="add_tailscale_repo_gpgkey.sh" profiles="Tumbleweed.RaspberryPi4,Tumbleweed.ARM64EFI">
         <source path="https://pkgs.tailscale.com/stable/opensuse/tumbleweed/aarch64"/>
     </repository>
-
-    <!-- https://osinside.github.io/kiwi/working_with_kiwi/xml_description.html#adding-repositories -->
+    <!-- https://osinside.github.io/kiwi/concept_and_workflow/repository_setup.html -->
     <!-- Local-Repository on build host: for pre-installed rockstor package -->
-    <!--    <repository type="rpm-dir" alias="Local-Repository"> -->
+    <!--    <repository alias="Local-Repository"> -->
     <!--        <source path="dir:/mnt/localrepo"/> -->
     <!--    </repository> -->
-
     <!-- Resource Rockstor Testing channel during installer build only -->
     <!-- Rockstor repos are multi-arch from 15.4 onwards -->
-
-    <repository type="rpm-md" alias="Rockstor-Testing"
-                profiles="Leap15.5.x86_64,Leap15.5.RaspberryPi4,Leap15.5.ARM64EFI">
+    <repository type="rpm-md" alias="Rockstor-Testing" profiles="Leap15.5.x86_64,Leap15.5.RaspberryPi4,Leap15.5.ARM64EFI">
         <source path="http://updates.rockstor.com:8999/rockstor-testing/leap/15.5/"/>
     </repository>
-    <repository type="rpm-md" alias="Rockstor-Testing"
-                profiles="Leap15.6.x86_64,Leap15.6.RaspberryPi4,Leap15.6.ARM64EFI">
+    <repository type="rpm-md" alias="Rockstor-Testing" profiles="Leap15.6.x86_64,Leap15.6.RaspberryPi4,Leap15.6.ARM64EFI">
         <source path="http://updates.rockstor.com:8999/rockstor-testing/leap/15.6/"/>
     </repository>
-    <repository type="rpm-md" alias="Rockstor-Testing"
-                profiles="Tumbleweed.x86_64,Tumbleweed.RaspberryPi4,Tumbleweed.ARM64EFI">
+    <repository type="rpm-md" alias="Rockstor-Testing" profiles="Tumbleweed.x86_64,Tumbleweed.RaspberryPi4,Tumbleweed.ARM64EFI">
         <source path="http://updates.rockstor.com:8999/rockstor-testing/tumbleweed/"/>
     </repository>
-
     <!-- For shellinabox package -->
     <!-- https://build.opensuse.org/package/show/shells/shellinabox -->
     <!-- Lower priority (higher number) than default 99 to avoid other dev shell packages supplanting -->
@@ -368,38 +247,28 @@
     <!-- Rockstor home repo on OBS for Leap 15.3 + now hosts dual arch shellinabox -->
     <!-- Maintain lower priority to upstream in case shellinabox is added there -->
     <!-- https://build.opensuse.org/project/show/home:rockstor -->
-
-    <repository type="rpm-md" alias="home_rockstor" priority="105" imageinclude="true"
-                profiles="Leap15.5.x86_64,Leap15.5.RaspberryPi4,Leap15.5.ARM64EFI">
+    <repository type="rpm-md" alias="home_rockstor" priority="105" imageinclude="true" profiles="Leap15.5.x86_64,Leap15.5.RaspberryPi4,Leap15.5.ARM64EFI">
         <source path="https://download.opensuse.org/repositories/home:/rockstor/15.5/"/>
     </repository>
-    <repository type="rpm-md" alias="home_rockstor" priority="105" imageinclude="true"
-                profiles="Leap15.6.x86_64,Leap15.6.RaspberryPi4,Leap15.6.ARM64EFI">
+    <repository type="rpm-md" alias="home_rockstor" priority="105" imageinclude="true" profiles="Leap15.6.x86_64,Leap15.6.RaspberryPi4,Leap15.6.ARM64EFI">
         <source path="https://download.opensuse.org/repositories/home:/rockstor/15.6/"/>
     </repository>
-    <repository type="rpm-md" alias="home_rockstor" priority="105" imageinclude="true"
-                profiles="Tumbleweed.x86_64,Tumbleweed.RaspberryPi4,Tumbleweed.ARM64EFI">
+    <repository type="rpm-md" alias="home_rockstor" priority="105" imageinclude="true" profiles="Tumbleweed.x86_64,Tumbleweed.RaspberryPi4,Tumbleweed.ARM64EFI">
         <source path="https://download.opensuse.org/repositories/home:/rockstor/openSUSE_Tumbleweed/"/>
     </repository>
-
     <!-- This repo currently provides: systemd-presets-branding-rockstor -->
     <!-- As per https://en.opensuse.org/Archive:Making_an_openSUSE_based_distribution -->
     <!-- We are required to de/re-brand packages that have no "...branding-upstream" equivalent -->
     <!-- https://build.opensuse.org/package/show/home:rockstor:branches:Base:System/systemd-presets-branding-rockstor -->
-
-    <repository type="rpm-md" alias="home_rockstor_branches_Base_System" priority="97" imageinclude="true"
-                profiles="Leap15.5.x86_64,Leap15.5.RaspberryPi4,Leap15.5.ARM64EFI">
+    <repository type="rpm-md" alias="home_rockstor_branches_Base_System" priority="97" imageinclude="true" profiles="Leap15.5.x86_64,Leap15.5.RaspberryPi4,Leap15.5.ARM64EFI">
         <source path="https://download.opensuse.org/repositories/home:/rockstor:/branches:/Base:/System/15.5/"/>
     </repository>
-    <repository type="rpm-md" alias="home_rockstor_branches_Base_System" priority="97" imageinclude="true"
-                profiles="Leap15.6.x86_64,Leap15.6.RaspberryPi4,Leap15.6.ARM64EFI">
+    <repository type="rpm-md" alias="home_rockstor_branches_Base_System" priority="97" imageinclude="true" profiles="Leap15.6.x86_64,Leap15.6.RaspberryPi4,Leap15.6.ARM64EFI">
         <source path="https://download.opensuse.org/repositories/home:/rockstor:/branches:/Base:/System/15.5/"/>
     </repository>
-    <repository type="rpm-md" alias="home_rockstor_branches_Base_System" priority="97" imageinclude="true"
-                profiles="Tumbleweed.x86_64,Tumbleweed.RaspberryPi4,Tumbleweed.ARM64EFI">
+    <repository type="rpm-md" alias="home_rockstor_branches_Base_System" priority="97" imageinclude="true" profiles="Tumbleweed.x86_64,Tumbleweed.RaspberryPi4,Tumbleweed.ARM64EFI">
         <source path="https://download.opensuse.org/repositories/home:/rockstor:/branches:/Base:/System/openSUSE_Tumbleweed/"/>
     </repository>
-
     <!-- THE FOLLOWING KERNEL REPOS ARE NOT SUPPORTED. -->
     <!-- Provided here remarked-out for developer convenience only. -->
     <!-- https://doc.opensuse.org/documentation/leap/reference/html/book-reference/cha-tuning-multikernel.html -->
@@ -425,9 +294,8 @@
     <!--                profiles="Leap15.5.x86_64,Leap15.5.RaspberryPi4,Leap15.5.ARM64EFI"> -->
     <!--        <source path="https://download.opensuse.org/repositories/filesystems/15.5/"/> -->
     <!--    </repository> -->
-
     <packages type="image">
-        <package name="adaptec-firmware"/>  <!-- Razor AIC94xx Series SAS -->
+        <package name="adaptec-firmware"/> <!-- Razor AIC94xx Series SAS -->
         <package name="bash-completion"/>
         <package name="bind-utils"/>
         <package name="btrfsmaintenance"/>
@@ -463,11 +331,11 @@
         <package name="kernel-default"/>
         <package name="kernel-firmware-bnx2"/> <!-- 10.8MiB - Broadcom net drivers -->
         <package name="kernel-firmware-chelsio"/> <!-- 2.9 MiB - Chelsio net drivers -->
-        <package name="kernel-firmware-intel"/> <!-- 2.5MiB - Intel platform drivers -->
+        <package name="kernel-firmware-intel"/> <!-- 2.5 MiB - Intel platform drivers -->
         <package name="kernel-firmware-marvell"/> <!-- 2.3 MiB - Marvell net drivers -->
-        <package name="kernel-firmware-network"/> <!-- 3.6MiB misc net drivers -->
+        <package name="kernel-firmware-network"/> <!-- 3.6 MiB misc net drivers -->
         <package name="kernel-firmware-platform"/> <!-- 1.6 MiB - misc platform drivers -->
-        <package name="kernel-firmware-qlogic"/> <!-- 12.8MiB - QLogic net drivers -->
+        <package name="kernel-firmware-qlogic"/> <!-- 12.8 MiB - QLogic net drivers -->
         <package name="keyutils"/>
         <package name="less"/>
         <package name="lsof"/>  <!-- for zypper ps -->
@@ -500,7 +368,6 @@
         <!-- ROCKSTOR PACKAGE: CHANGE VERSION AS REQUIRED -->
         <package name="rockstor-5.0.9-0"/>
     </packages>
-
     <packages type="image" profiles="Leap15.5.RaspberryPi4,Leap15.6.RaspberryPi4,Tumbleweed.RaspberryPi4">
         <package name="raspberrypi-eeprom" arch="aarch64"/>
         <package name="raspberrypi-firmware" arch="aarch64"/>
@@ -510,7 +377,6 @@
         <package name="bcm43xx-firmware"/>
         <package name="u-boot-rpiarm64" arch="aarch64"/>
     </packages>
-
     <packages type="bootstrap">
         <package name="ca-certificates"/>
         <!-- https://github.com/OSInside/kiwi/issues/776#issuecomment-403724943 -->


### PR DESCRIPTION
Update to latest schema version. Includes some incidental kiwi-ng doc url updates. Brings our format more in line with upstream (kiwi-ng) schema migraion tools re line-breaks etc.

Includes incidental update of author & contact info.

Fixes #169 