### PR TITLE
Account for bls grub changes in upstream #174

### DIFF
--- a/rockstor.kiwi
+++ b/rockstor.kiwi
@@ -49,7 +49,7 @@
         <!--        luks="c00l_Pa$$Phra$e" -->
         <!--        luks_version="luks2" -->
         <type image="oem" primary="true" initrd_system="dracut" filesystem="btrfs" fsmountoptions="noatime" firmware="efi" installiso="true" kernelcmdline="nomodeset plymouth.enable=0 rd.kiwi.oem.maxdisk=5000G" bootpartition="false" devicepersistency="by-label" btrfs_root_is_snapshot="true" btrfs_quota_groups="false" efipartsize="64">
-            <bootloader name="grub2"/>
+            <bootloader name="grub2" bls="false"/>
             <!-- For full disk LUKS encryption uncomment below entries -->
             <!-- PBKDF2 is required for grub to recognize encryption -->
             <!--    <luksformat> -->
@@ -88,7 +88,7 @@
         <!-- firmware="efi" See https://github.com/OSInside/kiwi/issues/1428 re AArch64 -->
         <!-- Re AArch64: https://github.com/OSInside/kiwi/issues/1491 -->
         <type image="oem" initrd_system="dracut" filesystem="btrfs" fsmountoptions="noatime,compress=lzo" firmware="efi" kernelcmdline="plymouth.enable=0 rd.kiwi.oem.maxdisk=5000G console=ttyS0,115200 console=tty" bootpartition="false" devicepersistency="by-uuid" btrfs_root_is_snapshot="true" btrfs_quota_groups="false" efipartsize="64" editbootinstall="editbootinstall_rpi.sh">
-            <bootloader name="grub2"/>
+            <bootloader name="grub2" bls="false"/>
             <systemdisk>
                 <volume name="home"/>
                 <volume name="root"/>
@@ -119,7 +119,7 @@
         <!-- firmware="efi" See https://github.com/OSInside/kiwi/issues/1428 re AArch64 -->
         <!-- Re AArch64: https://github.com/OSInside/kiwi/issues/1491 -->
         <type image="oem" initrd_system="dracut" filesystem="btrfs" fsmountoptions="noatime,compress=lzo" firmware="efi" kernelcmdline="plymouth.enable=0 rd.kiwi.oem.maxdisk=5000G earlycon" bootpartition="false" devicepersistency="by-uuid" btrfs_root_is_snapshot="true" btrfs_quota_groups="false" efipartsize="64" format="qcow2">
-            <bootloader name="grub2"/>
+            <bootloader name="grub2" bls="false"/>
             <systemdisk>
                 <volume name="home"/>
                 <volume name="root"/>


### PR DESCRIPTION
As from kiwi-ng 10.0.14 onwards, we should explicitly configure:

- bls="false" in all <preferences><type><bootloader> elements.

This enforces a default that is otherwise enacted by an rpm install on an openSUSE system.

Fixes #174 