### PR TITLE
Update _multibuild with Leap15.6 flavor

### DIFF
--- a/_multibuild
+++ b/_multibuild
@@ -1,5 +1,5 @@
 <multibuild>
-  <flavor>Leap15.5.x86_64</flavor>
-  <flavor>Leap15.5.RaspberryPi4</flavor>
-  <flavor>Leap15.5.ARM64EFI</flavor>
+  <flavor>Leap15.6.x86_64</flavor>
+  <flavor>Leap15.6.RaspberryPi4</flavor>
+  <flavor>Leap15.6.ARM64EFI</flavor>
 </multibuild>


### PR DESCRIPTION
Fixes #179 .

Updated flavors to reflect Leap 15.6 as the current build target. Assumption is that TW is still out of the picture for that and will require a separate effort.