### PR TITLE
revisit vagrant process

### DIFF
--- a/vagrant_env/README.md
+++ b/vagrant_env/README.md
@@ -1,78 +1,102 @@
 Introduction
 ------------
-You can use this vagrant environment to build the installer image within a vagrant box of a confirmed working 
-specification.
+You can use a vagrant environment to build the installer image within a vagrant box of a confirmed working specification.
+
 
 Pre-requisites
 -------------
 The following software packages should be installed on the host machine:
 - Vagrant (https://www.vagrantup.com/downloads)
-- VirtualBox (https://www.virtualbox.org/wiki/Downloads)
-- Oracle VM VirtualBox Extension Pack (https://www.virtualbox.org/wiki/Downloads)
+- VirtualBox and the  VirtualBox Extension Pack (https://www.virtualbox.org/wiki/Downloads)
 
 Both packages/extensions are available on Linux, Mac OSX and Windows.
 
-Also, a local copy of this repository [rockstor-installer](https://github.com/rockstor/rockstor-installer) on your machine, see the top level README.md, and are currently within the `vagrant_env` directory: where the `Vagrantfile`, `build.sh`, and `run_kiwi.sh` are located.
+Also, a local copy of this repository [rockstor-installer](https://github.com/rockstor/rockstor-installer) on your machine, see the top level README.md, and are currently within the `vagrant_env` directory: where the `Vagrantfile`, `initial_prep.sh`, `build.sh`, and `run_kiwi.sh` are located.
 
 A few notes on the processing flow:
 - Before bringing up the vagrant box, make adjustments to either of these files and also edit the `rockstor.kiwi` in the parent directory according to the options to be used (see top-level README.md).
-- Because the shared folder between the host and the VirtualBox VM cannot be accessed correctly by the KVM that the boxbuild generates, the 'run_kiwi.sh' file will be copied into the box from the host directory at the end of the vagrant box activation, so any changes should be done beforehand.
-- The `run_kiwi.sh` file in turn will then copy the `rockstor.kiwi` file into a fresh copy of the repository directly on the vagrant box, which is then accessible by the 'kiwi-ng' generated KVM.
-- At the end of the boxbuild process, the files in the resulting output directory will be copied back into the host directory, so they can then be used without having to be logged into the vagrant box. The final steps clean up the repository and the directory holding the iso file. This way a new build with other settings in `rockstor.kiwi` can be executed without having to recreate the vagrant box from scratch.
+- At the end of the build process, the files in the resulting output directory will be copied back into the host directory, so they can then be used without having to be logged into the vagrant box. The final steps clean up the repository and the directory holding the iso file. This way a new build with other settings in `rockstor.kiwi` can be repeatedly executed without having to recreate the vagrant box from scratch.
 
 Configuring Profiles
 --------------------
-NOTE: Currently, only the x86_64 profile is usable due to the availability of suitable vagrant boxes for 
-AArch64 in VirtualBox. 
+NOTE: Currently, only the x86_64 profile is usable due to the lack of availability of suitable vagrant boxes for 
+aarch64 in VirtualBox (the ones listed below for `aarch64` could be used if `libvirt` is the provider).
 
-<s>
-To configure the environment to build the required platform/profile you need to edit both the following files to 
-comment/uncomment the 'PROFILE' variable to the desired value:
-
-- Vagrantfile
-- run_kiwi.sh
-</s>
+To configure the environment to build the required platform/profile you need to edit `run_kiwi.sh` file to and update the 'PROFILE' variable to the desired value
 
 Vagrant Boxes for OpenSUSE Leap
 -------------------------------
 
 This vagrant file uses the vagrant boxes: 
-- [opensuse/leap-15.3.x86_64](https://app.vagrantup.com/opensuse/boxes/Leap-15.3.x86_64) or
-- [opensuse/leap-15.3.aarch64](https://app.vagrantup.com/opensuse/boxes/Leap-15.3.aarch64)
+- [opensuse/leap-15.6.x86_64](https://portal.cloud.hashicorp.com/vagrant/discover/opensuse/Leap-15.6.x86_64) or
+- [opensuse/Tumbleweed.x86_64](https://portal.cloud.hashicorp.com/vagrant/discover/opensuse/Tumbleweed.x86_64)
 
-which can be found in the `Vagrantfile` under this setting:
+only if using `libvirt` as the provider (untested in this set of instructions):
+- [opensuse/leap-15.6.aarch64](https://portal.cloud.hashicorp.com/vagrant/discover/opensuse/Leap-15.6.aarch64)
+- [opensuse/Tumbleweed.aarchx64](https://portal.cloud.hashicorp.com/vagrant/discover/opensuse/Tumbleweed.aarch64)
+
+If necessary, adjust these settings in the `Vagrantfile`:
 ```
-v.vm.box = 'opensuse/Leap-15.3.x86_64' 
+  config.vm.box = "opensuse/Leap-15.6.x86_64"
+  config.vm.box_version = "15.6.13.356" 
+```
+The values can be derived from the listed vagrant box, when looking at the `Option` boxes on the right-hand side on the vagrant box web page.
+Depending on the host system used for this, also adjust the number of CPUs and memory (in MB) in the file.
+Save and place the vagrant file in a directory where the vagrant instance should be brought up.
+
+
+Prepare the Vagrant Virtual Machine (using VirtualBox as provider)
+------------------------------------------------------------------
+Assuming that the Vagrant box directory essentially has the same directory structure and files as the `rockstor-installer` repo, and the Vagrant file was manually copied from the `vagrant_env` directory to the level above, change the directory to where the `Vagrantfile` is located.
+
+Execute (under windows)
+```shell script
+vagrant up
 ```
 
-These boxes for vagrant are based on official images with the virtualisation tools added.
+To ensure that the latest openSUSE patches and kiwi-ng pre-requisites are installed. For that activity run the script:
+```shell script
+vagrant ssh -c "/vagrant/vagrant_env/initial_prep.sh"
+```
+The default passwords to `ssh` into the vagrant box is `vagrant`.
 
-Note: in some instances when VirtualBox Guest Additions are not the same on the VirtualBox installation and the OpenSUSE image, problems can occur. In the Vagrantfile there is an option to edit (comment/uncomment) a bento based vagrant box of the LEAP OS, which has shown to work as well in a cinch.
+For the openSUSE patches, there is user confirmation is required, but the remainder of the updates should work without interaction. If during the update of the openSUSE packages a kernel update was performed, a reboot of the vagrant box will be required before continuing, using:
+
+```shell script
+vagrant reload
+```
+
+If the same vagrant virtual machine is going to be used some time later again for other builds, the above script can be rerun to ensure the latest packages are installed.
+Alternatively, one can enter the running machine with `vagrant ssh` and then run e.g. `sudo zypper up` and potentially reboot the virtual machine before proceeding to building a new iso.
+
+
+
 
 Building the Rockstor ISO installer
 -----------------------------------
-As indicated in the top-level readme, make adjustments to the 'rockstor.kiwi' in the top-level directory (e.g. `rockstor-installer`) before returning to the `vagrant-env` directory and initiate the rockstor ISO build.
+As indicated in the top-level readme, make any desired adjustments to the `rockstor.kiwi` in the top-level directory (e.g., `../rockstor-installer`) before initiating the rockstor ISO build.
+If not currently running, bring up the vagrant box with `vagrant up` (Note: make sure this is run in the top-level directory where the vagrant box was originally started from!).
 
 On Mac OSX, Linux and Windows with Bash installed, execute the build script:
 
 ```shell script
-./build.sh
+./vagrant_env/build.sh
 ```
 On Windows without Bash installed, execute:
 
-```
-vagrant up
-vagrant ssh -c "./run_kiwi.sh"
+```shell script
+vagrant ssh -c "/vagrant/run_kiwi.sh"
 ```
 
-This will build and provision the vagrant box. It will then run kiwi in the virtual machine to build the Rockstor 
-Installer ISO.
+This will then run kiwi-ng in the virtual machine to build the Rockstor installer ISO.
 
-The resultant ISO will be available in this directory. (e.g., ./rockstor-installer/kiwi-images)
+The resultant ISO will be available in the top-level directory outside of the virtual machine. (e.g., `../rockstor-installer/kiwi-images`).
+
+
 
 Managing the Virtual Machine
 ----------------------------
-To manage the Vagrant box VM simple type the following from the directory where the respective vagrant file is located (in this case it would be the vagrant_env folder)
+To manage the Vagrant box VM simply type the following from the directory where the respective vagrant file is located (e.g., `../rockstor-installer`)
 
 - Bring up a vagrant box VM
 

--- a/vagrant_env/initial_prep.sh
+++ b/vagrant_env/initial_prep.sh
@@ -1,0 +1,32 @@
+#!/bin/bash
+# Bash parameters
+set -e
+set -u
+#set -x
+
+echo "================================================="
+echo "update vagrant image with latest openSUSE updates"
+echo "================================================="
+sudo zypper refresh
+sudo zypper up
+
+echo "================================================="
+echo "add Python 3.11 and git packages"
+echo "================================================="
+sudo zypper -n install python311 git
+
+echo "================================================="
+echo "install kiwi-ng 10.x and other dependencies"
+echo "================================================="
+sudo zypper -n addrepo http://download.opensuse.org/repositories/Virtualization:/Appliances:/Builder/openSUSE_Leap_15.6/ appliance-builder
+sudo zypper --gpg-auto-import-keys refresh appliance-builder
+sudo zypper -n install python311-kiwi btrfsprogs gfxboot qemu-tools gptfdisk e2fsprogs squashfs xorriso dosfstools binutils xz
+
+echo "================================================="
+echo "verify kiwi-ng version. 10.1 or higher"
+echo "================================================="
+sudo kiwi-ng --version
+
+echo "================================================="
+echo "Done"
+echo "================================================="

--- a/vagrant_env/initial_prep.sh
+++ b/vagrant_env/initial_prep.sh
@@ -18,8 +18,9 @@ sudo zypper -n install python311 git
 echo "================================================="
 echo "install kiwi-ng 10.x and other dependencies"
 echo "================================================="
-sudo zypper -n addrepo http://download.opensuse.org/repositories/Virtualization:/Appliances:/Builder/openSUSE_Leap_15.6/ appliance-builder
+sudo zypper -n addrepo https://download.opensuse.org/repositories/Virtualization:/Appliances:/Builder/openSUSE_Leap_15.6/ appliance-builder
 sudo zypper --gpg-auto-import-keys refresh appliance-builder
+# for TW kiwi-ng package = python3-kiwi for LEAP 15.6 = python311-kiwi
 sudo zypper -n install python311-kiwi btrfsprogs gfxboot qemu-tools gptfdisk e2fsprogs squashfs xorriso dosfstools binutils xz
 
 echo "================================================="

--- a/vagrant_env/run_kiwi.sh
+++ b/vagrant_env/run_kiwi.sh
@@ -4,60 +4,103 @@ set -e
 set -u
 #set -x
 
-# Processing Profile Parameters
-PROFILE="Leap15.3.x86_64"
+echo "setting Profile Parameter"
+# rockstor.kiwi profile to be used during iso generation
+PROFILE="Leap15.6.x86_64"
 
+echo "============================================="
+echo "Initialization"
+echo "============================================="
+echo "setting profile parameters"
+echo "============================================="
+
+# if boxplugin were to be used
 # Memory and CPUs need to be less than stipulated in the Vagrantfile
-MEM="6G"
-CPU="3"
+# MEM="6G"
+# CPU="3"
 
-# Set Path Variables
+# Vagrant Home Path
 HOME_PATH="/home/vagrant"
-REPO_SOURCE_PATH="/home/vagrant/rockstor-installer"
+# Default shared folder with Vagrant Host
+REPO_SOURCE_PATH="/vagrant"
+# cloned Repo Path inside Vagrant Box
 REPO_PATH="/home/vagrant/repo"
+# Github Repository to be cloned
 REPO_URL="https://github.com/rockstor/rockstor-installer.git"
-KIWI_NG_PATH="/home/vagrant/kiwi-env/bin"
-KIWI_IMAGES="/home/vagrant/kiwi-images/"
+# Kiwi-ng executable Path
+KIWI_NG_PATH="/usr/bin"
+# Kiwi-ng final image storage location
+KIWI_IMAGES="/home/vagrant/kiwi-images"
+
 DESCRIPTION="./"
 
-echo '============================================='
-echo 'Starting Build'
-echo '============================================='
-echo 'Get most recent git into Vagrant Box'
-echo '============================================='
+echo "============================================="
+echo "clean up relevant directories"
+echo "============================================="
 
-if [ ! -e ${REPO_PATH} ]; then
-	sudo git clone ${REPO_URL} ${REPO_PATH}
+if [ -a "$KIWI_IMAGES" ]; then
+   echo "kiwi images directory exists and will be deleted"
+   sudo rm -rf "$KIWI_IMAGES"
+else
+   echo "no cleanup required"
 fi
 
-echo '============================================='
-echo 'insert rockstor.kiwi from local directory'
-echo '============================================='
-# force copy to have the latest version inside the vagrant box
-sudo cp -fv "$REPO_SOURCE_PATH"/rockstor.kiwi "$REPO_PATH"/rockstor.kiwi
+if [ -a "$REPO_PATH" ]; then
+   echo "repository directory exists and will be deleted"
+   sudo rm -rf "$REPO_PATH"
+else
+   echo "no cleanup required"
+fi
 
-echo '============================================='
-echo 'executing kiwi-ng'
-echo '============================================='
+
+echo "================================================="
+echo "Starting Build"
+echo "================================================="
+echo "Get git into Vagrant Box"
+echo "================================================="
+
+if [ ! -e ${REPO_PATH} ]; then
+   echo "loading from github"
+   sudo git clone ${REPO_URL} ${REPO_PATH}
+fi
+
+echo "================================================="
+echo "insert updated rockstor.kiwi from local directory"
+echo "================================================="
+# force copy to have the latest version inside the vagrant box
+if [ -a "$REPO_SOURCE_PATH"/rockstor.kiwi ]; then
+   sudo cp -fv "$REPO_SOURCE_PATH"/rockstor.kiwi "$REPO_PATH"/rockstor.kiwi
+else
+   echo "using rockstor.kiwi file from github instead"
+fi
+
+echo "================================================="
+echo "executing kiwi-ng"
+echo "================================================="
 # change into repo directory before executing kiwi-ng
 cd "$REPO_PATH"
-sudo "$KIWI_NG_PATH"/kiwi-ng --profile="$PROFILE" --type oem system boxbuild --box-memory "$MEM" --box-smp-cpus="$CPU" --box leap -- --description "$DESCRIPTION" --target-dir "$KIWI_IMAGES"
+# sudo "$KIWI_NG_PATH"/kiwi-ng --profile="$PROFILE" --type oem system boxbuild --box-memory "$MEM" --box-smp-cpus="$CPU" --box leap -- --description "$DESCRIPTION" --target-dir "$KIWI_IMAGES"
+sudo "$KIWI_NG_PATH"/kiwi-ng --profile="$PROFILE" --type oem system build --description "$DESCRIPTION" --target-dir "$KIWI_IMAGES"
 
-echo '============================================='
-echo 'Copying image directory to local'
-echo '============================================='
-# force copy to outside of vagrant box
-sudo cp -fRv "$KIWI_IMAGES" "$REPO_SOURCE_PATH"
+echo "================================================="
+echo "Copying image directory to local"
+echo "================================================="
+# wildcard expressions should be outside of the quotes to not be interpreted as string
+sudo cp -f "$KIWI_IMAGES/"Rockstor* "$REPO_SOURCE_PATH/kiwi-images"
+sudo cp -f "$KIWI_IMAGES/"kiwi*.* "$REPO_SOURCE_PATH/kiwi-images"
+sudo cp -f "$KIWI_IMAGES/build/image-root.log" "$REPO_SOURCE_PATH/kiwi-images"
 
-echo '============================================='
-echo 'Clean up kiwi-images and git repo'
-echo '============================================='
-cd "$HOME_PATH"
+echo "================================================="
+echo "Clean up kiwi-images and git repo"
+echo "================================================="
+
 sudo rm -rf "$KIWI_IMAGES"
 sudo rm -rf "$REPO_PATH"
-echo '============================================='
-echo 'Finished Build'
-echo '============================================='
-echo 'Status and result logs can be found in "$REPO_SOURCE_PATH" directory'
-echo 'Auf Wiedersehen'
-echo '============================================='
+
+echo "================================================="
+echo "Finished Build"
+echo "================================================="
+echo "Status and result logs can be found"
+echo "in $REPO_SOURCE_PATH directory"
+echo "Auf Wiedersehen"
+echo "================================================="


### PR DESCRIPTION
Fixes #182.

- simplified (hopefully) the vagrant process, removing the boxbuild version within the vagrant machine
- Identified additional package requirements (not sure whether that's for the vagrant openSUSE box): `binutils` (for the `strings` command) and `xz` - created new initialization script to prepare the vagrant box
- updated the run_kiwi script
- updated documentation to reflect change in approach