### PR TITLE
grub theme upstream not found #189

### DIFF
--- a/rockstor.kiwi
+++ b/rockstor.kiwi
@@ -40,7 +40,7 @@
         <rpm-excludedocs>true</rpm-excludedocs>
         <rpm-check-signatures>false</rpm-check-signatures>
         <bootsplash-theme>upstream</bootsplash-theme>
-        <bootloader-theme>upstream</bootloader-theme>
+        <bootloader-theme>starfield</bootloader-theme>
         <!-- firmware="efi" See https://github.com/OSInside/kiwi/issues/1428 re AArch64 -->
         <!-- Re AArch64: https://github.com/OSInside/kiwi/issues/1491 -->
         <!-- For root disk LUKS encryption (using luks2 & PBKDF2 instead of argon2id) -->
@@ -84,7 +84,7 @@
         <rpm-excludedocs>true</rpm-excludedocs>
         <rpm-check-signatures>false</rpm-check-signatures>
         <bootsplash-theme>upstream</bootsplash-theme>
-        <bootloader-theme>upstream</bootloader-theme>
+        <bootloader-theme>starfield</bootloader-theme>
         <!-- firmware="efi" See https://github.com/OSInside/kiwi/issues/1428 re AArch64 -->
         <!-- Re AArch64: https://github.com/OSInside/kiwi/issues/1491 -->
         <type image="oem" initrd_system="dracut" filesystem="btrfs" fsmountoptions="noatime,compress=lzo" firmware="efi" kernelcmdline="plymouth.enable=0 rd.kiwi.oem.maxdisk=5000G console=ttyS0,115200 console=tty" bootpartition="false" devicepersistency="by-uuid" btrfs_root_is_subvolume="true" btrfs_root_is_snapshot="true" btrfs_quota_groups="false" efipartsize="64" editbootinstall="editbootinstall_rpi.sh">
@@ -115,7 +115,7 @@
         <rpm-excludedocs>true</rpm-excludedocs>
         <rpm-check-signatures>false</rpm-check-signatures>
         <bootsplash-theme>upstream</bootsplash-theme>
-        <bootloader-theme>upstream</bootloader-theme>
+        <bootloader-theme>starfield</bootloader-theme>
         <!-- firmware="efi" See https://github.com/OSInside/kiwi/issues/1428 re AArch64 -->
         <!-- Re AArch64: https://github.com/OSInside/kiwi/issues/1491 -->
         <type image="oem" initrd_system="dracut" filesystem="btrfs" fsmountoptions="noatime,compress=lzo" firmware="efi" kernelcmdline="plymouth.enable=0 rd.kiwi.oem.maxdisk=5000G earlycon" bootpartition="false" devicepersistency="by-uuid" btrfs_root_is_subvolume="true" btrfs_root_is_snapshot="true" btrfs_quota_groups="false" efipartsize="64" format="qcow2">


### PR DESCRIPTION
Replace nonexistent grub theme placeholder of 'upstream', with 'starfield', the "Default theme for GRUB2" already installed via the 'grub2-branding-upstream' package.

Fixes #189