### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,14 +1,15 @@
 
-# Rockstor 4 Installer Recipe
+# Rockstor "Built on openSUSE" Installer Recipe
 
-This repo contains the [kiwi-ng](https://github.com/OSInside/kiwi) configuration used to create Rockstor 4 'Built on openSUSE' installers.
+This repo contains the [kiwi-ng](https://github.com/OSInside/kiwi) configuration used to create Rockstor 'Built on openSUSE' installers.
 Please see the excellent [kiwi ng docs](https://osinside.github.io/kiwi/) for configuration options.
 
 Pull requests most welcome; especially new target system profiles.
 Please test your modifications on all affected profiles prior to submission and provide details of how you tested the resulting installer.
 
 ## Profile Anatomy
-Profiles are named after their upstream distribution base, i.e. openSUSE Leap version, and then the intended target system; the two elements separated by a ".".
+Profiles are named after their upstream distribution base, i.e. openSUSE Leap version,
+and then the intended target system; with the two elements separated by a ".".
 
 The "target system" element is either generic, i.e. **x86_64** or **AArch64**, or target system specific, i.e. **RaspberryPi4** or **ARM64EFI**.
 With the latter ARM64EFI spanning both generic (Arm64) and specific (64 bit EFI).
@@ -16,43 +17,48 @@ With the latter ARM64EFI spanning both generic (Arm64) and specific (64 bit EFI)
 ## Core Profiles
 Our current pre-built installers are built using the following profiles (see: [Downloads](https://rockstor.com/dls.html)):
 
-- **Leap15.5.x86_64**
-- **Leap15.5.RaspberryPi4** (supports RPi400 also)
-- **Leap15.5.ARM64EFI** (N.B. Full Ten64 compatibility awaiting mcbridematt repo update)
+- **Leap15.6.x86_64**
+- **Leap15.6.RaspberryPi4**
+- **Leap15.6.ARM64EFI**
+- **Tumbleweed.x86_64**
+- **Tumbleweed.RaspberryPi4**
+- **Tumbleweed.ARM64EFI**
 
-### Contributing a Profile
-If you would like to add a specific target system installer profile, please take a look at the [examples](https://github.com/OSInside/kiwi-descriptions) referenced in the second link above.
-The `rockstor.kiwi` file itself also contains comments with links to example configs used during its development. 
-We can make no promises for the 'supported' status of any additional profiles but '[The Rockstor Project](https://rockstor.com/about-us.html)' will endeavour to make available the more popular resulting installers.
+### Pi4 USB boot
+USB booting on the Pi4 may require a bootloader update via a fully updated Raspberry OS.
+Pi4 EEPROM/bootloader version "Jun 15 2020" or later will be required for USB boot,
+regardless of any installer/EFI file changes.
 
-### Raspberry Pi4 Notes:
-This installer requires a recent Raspberry OS initiated firmware updates to be booted from a USB device.
-However, regular microSD card boot should work out-of-the-box without a more modern firmware in the Pi4.
-
-### Broken Profiles
-Prior to Tumbleweed dropping some Python 2 libraries this profile was functional.
-We used this target to inform our developmental direction and as a more leading-edge installer option. 
-We are preserving this profile for when our in-process Python 2 to 3 move is complete.
-Note however that it is not currently maintained.
-Please contribute to this profile if you are interested as we would very much like to again be available in the Tumbleweeds.
-
-### Special mention:
+### Special mention
 - ARM64EFI
 
-We are very excited to welcome contributions for the innovative [Traverse Ten64](https://www.crowdsupply.com/traverse-technologies/ten64) AArch64 platform.
-[Traverse technologies](https://traverse.com.au/) are an important contributor to the [rockstor-core](https://github.com/rockstor/rockstor-core) code base
-and have been instrumental in achieving our initial AArch64 aims.
+We are fortunate & thankful to have had contributions from/for the innovative [Traverse Ten64](https://www.crowdsupply.com/traverse-technologies/ten64) AArch64 platform.
+[Traverse technologies](https://traverse.com.au/) have been instrumental in achieving our initial AArch64 compatibility aims.
 The resulting installer is intended to support 64-bit ARM systems that implement the [Embedded Boot](https://github.com/ARM-software/ebbr) or [Server boot](https://github.com/ARM-software/sbsa-acs) standard.
-Note that additional drives may be required for your specific hardware, if so consider [Installing the Stable Kernel Backport](https://rockstor.com/docs/howtos/stable_kernel_backport.html).
+Note that additional drives may be required for your specific hardware,
+if so consider [Installing the Stable Kernel Backport](https://rockstor.com/docs/howtos/stable_kernel_backport.html).
 Also see the following subsection for enabling these same repositories/facilities within the resulting installer itself.
+
+## Contributing a Profile
+If you would like to add a specific target system installer profile,
+please take a look at the [examples](https://github.com/OSInside/kiwi-descriptions) referenced in the second link above.
+The `rockstor.kiwi` file itself also contains comments with links to example configs used during its development. 
+We can make no promises for the 'supported' status of any additional profiles,
+but '[The Rockstor Project](https://rockstor.com/about-us.html)' will endeavour to make available the more popular resulting installers.
+See our [Community Contributions](https://rockstor.com/docs/contribute_section.html) doc section for an overview to contributing,
+and the [howto subsection](#howto) below to test proposed changes. 
 
 ## HOWTO
 
-Please see the [overview](https://osinside.github.io/kiwi/overview.html) section of the kiwi-ng docs for the canonical
-[System Requirements](https://osinside.github.io/kiwi/overview.html#system-requirements) for building the installer: e.g., 15 GB free space, Python version, etc.
+Please see the [kiwi-ng docs overview](https://osinside.github.io/kiwi/overview.html) for the canonical
+[System Requirements](https://osinside.github.io/kiwi/overview.html#system-requirements) for building the installer:
+e.g., 15 GB free space, Python version, etc.
+It is recommended to use at least Kiwi-ng v10.1.18 to build our [Core Profiles](#core-profiles).
 
-Given our image target OS is exclusively 'Built on openSUSE', a vanilla openSUSE Leap 15.5 install is recommended if not using the kiwi-ng boxbuild method.
-But if the newer kiwi-ng boxbuild method in "Building on any linux host... " is used, any relatively modern linux system can be used to build the installer.
+Given our profiles' target OSs are exclusively 'Built on openSUSE',
+a vanilla openSUSE Leap 15.5/6 instance is recommended if not using the kiwi-ng boxbuild method.
+But if the newer kiwi-ng boxbuild method in "Building on any linux host... " is used,
+any relatively modern linux system can be used to build the installer.
 
 ### rockstor-installer local copy
 
@@ -66,16 +72,19 @@ git clone https://github.com/rockstor/rockstor-installer.git
 cd rockstor-installer/
 ```  
 
-The above commands install the 'git' program, and use it to 'clone' (read copy locally) the GitHub repo, before setting your working directory to be inside this local copy.
-Now you just need the kiwi-ng program this config requires to make the final installer. 
+The above commands install the 'git' program, and use it to 'clone' (read copy locally) the GitHub repo,
+before setting your working directory to be inside this local copy.
+Now you just need the kiwi-ng program this config requires to make the actual installer. 
 
 ### Building on any linux host (KVM support required)
 Kiwi now has support for using KVM virtual machines to build in an isolated environments, regardless of the linux host.
 
-With the release of version 10.x of `kiwi ng` the minimum required python version is now `3.9` or higher. On any linux platform with KVM virtualization enabled, 
-and the corresponding python3 version, you can use an isolated python virtual environment to build the installer without modifying your host OS,
+With the release of version 10.x of `kiwi ng` the minimum required python version is now `3.9` or higher.
+On any linux platform with KVM virtualization enabled and the corresponding python3 version,
+you can use an isolated python virtual environment to build the installer without modifying your host OS,
 or needing to manually set up an openSUSE virtual machine (see below for this alternative).
-This boxbuild approach does have some overheads compared to building on a baremetal installation, but on reasonably powerful hardware it can still take less than twenty minutes.
+This boxbuild approach does have some overheads compared to building on a baremetal installation,
+but on reasonably powerful hardware it can still take less than twenty minutes.
 
 By default, the kiwi-boxed-plugin will reserve 8GB of memory, and 4 CPU cores.
 This can be modified with `--box-memory=<vm>G --box-smp-cpus=<number>`, e.g., `--box-memory 4G --box-smp-cpus=2`.
@@ -84,13 +93,18 @@ Assigning too much RAM will crash your host, so be sure to set a safe amount sma
 Arguments before the `--` are passed to boxbuild, and after are passed to the kiwi-ng build itself.
 
 **Note on using a host OS within a Virtual Machine:**
-If using a Linux OS in a Virtual Machine, any shared folders from the host are not properly recognized by the KVM/QEMU that is generated by `kiwi-ng`'s boxbuild approach.
+If using a Linux OS in a Virtual Machine,
+any shared folders from the host are not properly recognized by the KVM/QEMU that is generated by `kiwi-ng`'s boxbuild approach.
 This can lead to `chroot` errors and terminate the installer generation.
-The recommendation in this case is to clone the installer git directly into the VM directory and edit the relevant files (e.g., `rockstor.kiwi`) before executing the box build; or edit them outside of the VM and transfer them back into the VM's installer directory using a shared folder.
+The recommendation in this case is to clone the installer git directly into the VM directory,
+and edit the relevant files (e.g., `rockstor.kiwi`) before executing the box build.
+Or to edit them outside of the VM and transfer them back into the VM's installer directory using a shared folder.
 At the end of installer creation the `.iso` file must then be copied from within the VM directory back onto the VM's host for further use.
 
 **Note on `pip` usage:**
-Some distros might still have a split between Python 2.x/3.x usage of `pip` (i.e. pip3 vs. pip), or an existing system that is being used had both installed over time. If that is the case, one wants to ensure that the 3.x version is used, by explicitly declaring `pip3` in the below command line. 
+Some distros might still have a split between Python 2.x/3.x usage of `pip` (i.e. pip3 vs. pip),
+or an existing system that is being used had both installed over time.
+If that is the case, one wants to ensure that the 3.x version is used, by explicitly declaring `pip3` in the below command line. 
 Otherwise, this can lead to execution errors down the line.
 
 ```shell
@@ -98,8 +112,11 @@ python3 -m venv kiwi-env
 ```
 
 **Note on virtual environment with a specific python3 version:**
-In case multiple python3 versions are installed (e.g., 3.11 was added to enable the usage of `kiwi`), the `venv` should be created using the specific version. Otherwise, the kiwi and box-plugin versions will revert to a lower version than 10x.
-Therefore, unless the higher python3 version has been set up to be the default version, the virtual environment should be created (using the example of version `3.11`):
+In case multiple python3 versions are installed (e.g., 3.11 was added to enable the usage of `kiwi`),
+the `venv` should be created using the specific version.
+Otherwise, the kiwi and box-plugin versions will revert to a lower version than 10x.
+Therefore, unless the higher python3 version has been set up to be the default version,
+the virtual environment should be created (using the example of version `3.11`):
 
 ```shell
 python3.11 -m venv kiwi-env
@@ -123,49 +140,46 @@ The rest remains the same (make sure to consider the memory and CPU defaults men
 This was the preferred method before the above kiwi-ng boxbuild capability existed.
 
 #### kiwi-ng install
-For an openSUSE Leap 15.5 OS from kiwi-ng's doc [Installation](https://osinside.github.io/kiwi/installation.html#installation) section we have:
+For an openSUSE Leap 15.5/6 OS from kiwi-ng's doc [Installation](https://osinside.github.io/kiwi/installation.html#installation) section we have:
 
 #### x86_64 host for x86_64 profiles
-Any x86_64 machine, although keep in mind that building the ISO installer is computationally expensive, so systems with a decent-sized CPU/RAM combination 
-released in the last 5-7 years is recommended.
+Any x86_64 machine, keeping in mind that building an installer is computationally expensive,
+so systems with a decent-sized CPU/RAM combination released in the last 5-7 years is recommended.
 
-##### Leap 15.5 host
-The openSUSE host version should ideally be at least the version of the target profile. Since Leap 15.5 ships with a `python 3.6x` it is necessary 
-to install a higher python version (e.g., `3.11`):
+##### Leap 15.5/6 host
+The openSUSE host version should ideally be at least the version of the target profile.
+Since Leap 15.5/6 ships with a default `python 3.6x` it is necessary to install a higher python version (e.g., `3.11`):
 
 ```shell
 sudo zypper in python311
 ```
 
-then add the required repository and install kiwi and the additional requirements as shown below:
+then add the required repository:
+
+for 15.5:
 
 ```shell
 sudo zypper addrepo http://download.opensuse.org/repositories/Virtualization:/Appliances:/Builder/openSUSE_Leap_15.5/ appliance-builder
+```
+
+or for 15.6
+
+```shell
+sudo zypper addrepo https://download.opensuse.org/repositories/Virtualization:/Appliances:/Builder/openSUSE_Leap_15.6/ appliance-builder
+```
+
+and install kiwi and the additional requirements as shown below:
+
+```shell
 sudo zypper install python3-kiwi btrfsprogs gfxboot qemu-tools gptfdisk e2fsprogs squashfs xorriso dosfstools
 ```
 
 #### AArch64 host (e.g., a Pi4) for AArch64 profiles
 See [HCL:Raspberry Pi4](https://en.opensuse.org/HCL:Raspberry_Pi4).
-Install, for example, an appliance JeOS Leap 15.5 image as the host OS.
-Enabling USB boot on older Pi4 systems will allow for the use of, for example, an SSD as the system drive which will massively speed up installer building.
-USB booting on the Pi4 may require a bootloader update via a fully updated Raspberry OS.
-
-Pi4 EEPROM/bootloader version "Jun 15 2020" or later will be required for USB boot regardless of any installer /EFI file changes.
-
-##### For a JeOS Leap 15.5 host:
-(Leap 15.3 and higher has moved to mixed X86_64/aarch64 repos). Since Leap 15.5 ships with a `python 3.6x` it is necessary 
-to install a higher python version (e.g., `3.11`):
-
-```shell
-sudo zypper in python311
-```
-
-then add the required repository and install kiwi and the additional requirements as shown below:
-
-```shell
-sudo zypper addrepo https://download.opensuse.org/repositories/Virtualization:/Appliances:/Builder/openSUSE_Leap_15.5/ appliance-builder
-sudo zypper install python3-kiwi btrfsprogs qemu-tools gptfdisk e2fsprogs squashfs xorriso dosfstools
-```
+Install, for example, an appliance JeOS Leap 15.5/6 image as the host OS.
+Enabling USB boot on older Pi4 systems will allow for the use of, for example,
+an SSD as the system drive which will massively speed up installer building.
+See [Pi4 USB boot](#pi4-usb-boot).
 
 ### Edit rockstor.kiwi
 No edit is required if you wish to use the generic installer filename and default rockstor package version (recommended).
@@ -173,30 +187,32 @@ To change these defaults edit all lines directly preceded by **<!--Change to ...
 Our release infrastructure performs these same edits to set official installer filenames and rockstor package versions.
 
 #### Stable Kernel Backport & matching btrfs-progs
-To enable the use of 'Stable Kernel Backport' and 'filesystems' repositories within our `rockstor.kiwi` config uncomment the 
-corresponding repositories already put into the file. For more information about using the most recent kernels 
-see [Installing the Stable Kernel Backport](https://rockstor.com/docs/howtos/stable_kernel_backport.html) for more information.
+To enable the use of 'Stable Kernel Backport' and 'filesystems' repositories within our `rockstor.kiwi` config,
+uncomment the corresponding repositories.
+For more information about using the most recent kernels see
+[Installing the Stable Kernel Backport](https://rockstor.com/docs/howtos/stable_kernel_backport.html).
 
 #### Root disk LUKS encryption
-If you want to enable LUKS encryption of the Root disk (where Rockstor is installed), uncomment the relevant parameters
-that are available in the **Leap15.5.x86_64** profile which are preceded by relevant comments. This will enable `luks2` encryption
-and utilize PBKDF2, as grub does not yet support the more recent `argon2id` algorithm.
+If you want to enable LUKS encryption of the Root disk (where Rockstor is installed),
+uncomment the relevant parameters available as example in the **Leap15.5.x86_64** profile.
+This will enable `LUKS2` encryption and utilize PBKDF2, as grub does not yet support the more recent `argon2id` algorithm.
 
-N.B.: The `luksformat` parameter's preceding hyphens have to be escaped so they can be held as as a comment. When adding more non-commented
-parameters, the required double-hyphens can be inserted without escaping them to their Unicode character codes.
+N.B.: The `luksformat` parameter's preceding hyphens have to be escaped to exist as a comment.
+When adding more non-commented parameters,
+the required double-hyphens can be inserted without escaping them to their Unicode character codes.
 
-### Leap15.5.x86_64 profile
+### Leap15.6.x86_64 profile
 Executed, as the root user, in the directory containing this repository's `rockstor.kiwi` file.
+
 ```shell
-kiwi-ng --profile=Leap15.5.x86_64 --type oem system build --description ./ --target-dir /home/kiwi-images/
+kiwi-ng --profile=Leap15.6.x86_64 --type oem system build --description ./ --target-dir /home/kiwi-images/
 ```
 
-### Leap15.5.RaspberryPi4 profile
+### Leap15.6.RaspberryPi4 profile
 Executed, as the root user, in the directory containing this repository's `rockstor.kiwi` file.
-N.B. RPi400 built-in keyboard is known not to work with this profile. 
 
 ```shell
-kiwi-ng --profile=Leap15.5.RaspberryPi4 --type oem system build --description ./ --target-dir /home/kiwi-images/
+kiwi-ng --profile=Leap15.6.RaspberryPi4 --type oem system build --description ./ --target-dir /home/kiwi-images/
 ```
 
 ## Resulting Rockstor installers
@@ -210,14 +226,18 @@ Use the file ending in ".raw".
 The resulting installs will grow on first boot to the size of their host devices.
 All partitioning is fully automatic.
 
-Please see [Rockstor’s “Built on openSUSE” installer](https://rockstor.com/docs/installer-howto/installer-howto.html) HowTo for a user guide.
+Please see [Rockstor’s “Built on openSUSE” installer](https://rockstor.com/docs/installer-howto/installer-howto.html) How-to for a user guide.
 
 ## Help or Assistance
-Our [friendly forum](https://forum.rockstor.com/) is a good place to ask question regarding this HowTo. If you enable some of the above described enhancements
-(like backported kernel, LUKS, or add other options yourself) please point those out when reporting any problems.
-Please be patient however, as our support is predominantly community based and the above procedure is not that well known by our community members.
-If you find an issue with this procedure and its associated kiwi-ng config, please consider creating and issue and submitting a pull request with any fixes 
-or improvements you consequently discover or invent.
+Our [friendly forum](https://forum.rockstor.com/) is a good place to ask question regarding this How-to.
+If you enable any of the above described enhancements i.e. backported kernel, LUKS, or add other options,
+be sure to include their details when reporting any problems.
+Please be patient as our support is community based and the above procedures are always in-flux/development.
 
-'The Rockstor Project' is a community endeavour and depends on [update channel](https://rockstor.com/docs/update-channels/update_channels.html)
-subscriptions and contributions for its continued open source development.  
+If you find an issues with these instructions, or the kiwi-ng config,
+please consider creating an issue and submitting a pull request with a proposed fix.
+
+[The Rockstor Project](https://opencollective.com/the-rockstor-project) is an [Open Collective](https://opencollective.com/)
+Non-Profit/Non-Business Open Source community endeavour.
+As such it depends on subscriptions and contributions for its sustainability.
+


### PR DESCRIPTION
General tidy-up and update regarding our available working profiles.

Includes:
- Add link to canonical Contributing to Rockstor doc sectino. Prioritizing 15.6.
- Removing note re broken Tumblweed profiles.
- Semantic linefeed updates.
- Remove duplicate info re Pi4 USB boot.
- Partially combine 15.5 & 15.6 host guides, post 15.5 EOL we remove its references entirely.
- Modernise our own references re Open Collective etc.

Fixes #141 

---

N.B. the changes here bring this repos README.md more in line with our Downloads page re available working profiles etc.