### PR TITLE
btrfs_root_is_snapshot to btrfs_root_is_snapper_snapshot #193

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,7 +53,7 @@ and the [howto subsection](#howto) below to test proposed changes.
 Please see the [kiwi-ng docs overview](https://osinside.github.io/kiwi/overview.html) for the canonical
 [System Requirements](https://osinside.github.io/kiwi/overview.html#system-requirements) for building the installer:
 e.g., 15 GB free space, Python version, etc.
-It is recommended to use at least Kiwi-ng v10.1.18 to build our [Core Profiles](#core-profiles).
+It is recommended to use at least Kiwi-ng v10.2.13 to build our [Core Profiles](#core-profiles).
 
 Given our profiles' target OSs are exclusively 'Built on openSUSE',
 a vanilla openSUSE Leap 15.5/6 instance is recommended if not using the kiwi-ng boxbuild method.

--- a/rockstor.kiwi
+++ b/rockstor.kiwi
@@ -9,7 +9,7 @@
 <!-- https://build.opensuse.org/package/show/openSUSE:Leap:15.5:Images/kiwi-templates-Minimal -->
 <!-- https://build.opensuse.org/package/show/openSUSE:Leap:15.5:Images/JeOS -->
 <!-- OBS-Profiles: @BUILD_FLAVOR@ -->
-<image schemaversion="8.1" name="Rockstor-NAS">
+<image schemaversion="8.3" name="Rockstor-NAS">
     <description type="system">
         <author>The Rockstor Project</author>
         <contact>support@rockstor.com</contact>
@@ -48,7 +48,7 @@
         <!-- note: change luks Pass Phrase -->
         <!--        luks="c00l_Pa$$Phra$e" -->
         <!--        luks_version="luks2" -->
-        <type image="oem" primary="true" initrd_system="dracut" filesystem="btrfs" fsmountoptions="noatime" firmware="efi" installiso="true" kernelcmdline="nomodeset plymouth.enable=0 rd.kiwi.oem.maxdisk=5000G" bootpartition="false" devicepersistency="by-label" btrfs_root_is_subvolume="true" btrfs_root_is_snapshot="true" btrfs_quota_groups="false" efipartsize="64">
+        <type image="oem" primary="true" initrd_system="dracut" filesystem="btrfs" fsmountoptions="noatime" firmware="efi" installiso="true" kernelcmdline="nomodeset plymouth.enable=0 rd.kiwi.oem.maxdisk=5000G" bootpartition="false" devicepersistency="by-label" btrfs_root_is_subvolume="true" btrfs_root_is_snapper_snapshot="true" btrfs_quota_groups="false" efipartsize="64">
             <bootloader name="grub2" bls="false"/>
             <!-- For full disk LUKS encryption uncomment below entries -->
             <!-- PBKDF2 is required for grub to recognize encryption -->
@@ -87,7 +87,7 @@
         <bootloader-theme>starfield</bootloader-theme>
         <!-- firmware="efi" See https://github.com/OSInside/kiwi/issues/1428 re AArch64 -->
         <!-- Re AArch64: https://github.com/OSInside/kiwi/issues/1491 -->
-        <type image="oem" initrd_system="dracut" filesystem="btrfs" fsmountoptions="noatime,compress=lzo" firmware="efi" kernelcmdline="plymouth.enable=0 rd.kiwi.oem.maxdisk=5000G console=ttyS0,115200 console=tty" bootpartition="false" devicepersistency="by-uuid" btrfs_root_is_subvolume="true" btrfs_root_is_snapshot="true" btrfs_quota_groups="false" efipartsize="64" editbootinstall="editbootinstall_rpi.sh">
+        <type image="oem" initrd_system="dracut" filesystem="btrfs" fsmountoptions="noatime,compress=lzo" firmware="efi" kernelcmdline="plymouth.enable=0 rd.kiwi.oem.maxdisk=5000G console=ttyS0,115200 console=tty" bootpartition="false" devicepersistency="by-uuid" btrfs_root_is_subvolume="true" btrfs_root_is_snapper_snapshot="true" btrfs_quota_groups="false" efipartsize="64" editbootinstall="editbootinstall_rpi.sh">
             <bootloader name="grub2" bls="false"/>
             <systemdisk>
                 <volume name="home"/>
@@ -118,7 +118,7 @@
         <bootloader-theme>starfield</bootloader-theme>
         <!-- firmware="efi" See https://github.com/OSInside/kiwi/issues/1428 re AArch64 -->
         <!-- Re AArch64: https://github.com/OSInside/kiwi/issues/1491 -->
-        <type image="oem" initrd_system="dracut" filesystem="btrfs" fsmountoptions="noatime,compress=lzo" firmware="efi" kernelcmdline="plymouth.enable=0 rd.kiwi.oem.maxdisk=5000G earlycon" bootpartition="false" devicepersistency="by-uuid" btrfs_root_is_subvolume="true" btrfs_root_is_snapshot="true" btrfs_quota_groups="false" efipartsize="64" format="qcow2">
+        <type image="oem" initrd_system="dracut" filesystem="btrfs" fsmountoptions="noatime,compress=lzo" firmware="efi" kernelcmdline="plymouth.enable=0 rd.kiwi.oem.maxdisk=5000G earlycon" bootpartition="false" devicepersistency="by-uuid" btrfs_root_is_subvolume="true" btrfs_root_is_snapper_snapshot="true" btrfs_quota_groups="false" efipartsize="64" format="qcow2">
             <bootloader name="grub2" bls="false"/>
             <systemdisk>
                 <volume name="home"/>
@@ -196,6 +196,18 @@
     </repository>
     <repository type="rpm-md" alias="repo-openh264" imageinclude="true" profiles="Tumbleweed.x86_64,Tumbleweed.RaspberryPi4,Tumbleweed.ARM64EFI">
         <source path="http://codecs.opensuse.org/openh264/openSUSE_Tumbleweed"/>
+    </repository>
+    <!-- Virtualization_Appliances_Builder repos: -->
+    <!-- Latest Kiwi-ng & Dracut helpers:  -->
+    <!-- https://build.opensuse.org/project/show/Virtualization:Appliances:Builder -->
+    <repository type="rpm-md" alias="Virtualization_Appliances_Builder" imageinclude="true" profiles="Leap15.5.x86_64,Leap15.5.RaspberryPi4,Leap15.5.ARM64EFI">
+        <source path="https://download.opensuse.org/repositories/Virtualization:/Appliances:/Builder/openSUSE_Leap_15.5/"/>
+    </repository>
+    <repository type="rpm-md" alias="Virtualization_Appliances_Builder" imageinclude="true" profiles="Leap15.6.x86_64,Leap15.6.RaspberryPi4,Leap15.6.ARM64EFI">
+        <source path="https://download.opensuse.org/repositories/Virtualization:/Appliances:/Builder/openSUSE_Leap_15.6/"/>
+    </repository>
+    <repository type="rpm-md" alias="Virtualization_Appliances_Builder" imageinclude="true" profiles="Tumbleweed.x86_64,Tumbleweed.RaspberryPi4,Tumbleweed.ARM64EFI">
+        <source path="https://download.opensuse.org/repositories/Virtualization:/Appliances:/Builder/openSUSE_Tumbleweed/"/>
     </repository>
     <!-- https://osinside.github.io/kiwi/concept_and_workflow/repository_setup.html -->
     <!-- Local-Repository on build host: for pre-installed rockstor package -->


### PR DESCRIPTION
Schema changed from 8.1 to 8.3.

Fixes #193 

Only 8.2 to 8.3 affects used configuration via:
'btrfs_root_is_snapshot' to 'btrfs_root_is_snapper_snapshot'

Requires a newer minimum version of Kiwi-ng & Dracut helpers. Address by adding Virtualization_Appliances_Builder to accommodate a recently increased requirement for near version matching between the Kiwi-ng used to build an image, and that image's built-in dracut, dracut-kiwi-oem-dump, and dracut-kiwi-oem-repart. I.e. also fix: "Reading /run/image/*.sha256 failed"