### PR TITLE
Failed to start JeOS First Boot Wizard - create system snapshot #177

### DIFF
--- a/config.sh
+++ b/config.sh
@@ -6,7 +6,9 @@
 # activation or deactivation of certain services (insserv). The call is not
 # made until after the switch to the image has been made with chroot.
 
-# https://osinside.github.io/kiwi/working_with_kiwi/shell_scripts.html
+# https://osinside.github.io/kiwi/concept_and_workflow/shell_scripts.html
+# "... usually used to apply a permanent and final change of data in the root tree,
+# such as modifying a package-specific config file."
 
 # Functions...
 #--------------------------------------
@@ -88,22 +90,6 @@ baseSetRunlevel 3
 #------------------------------------------
 rm -rf /usr/share/doc/packages/*
 rm -rf /usr/share/doc/manual/*
-
-#=====================================
-# Configure snapper
-#-------------------------------------
-if [ "$kiwi_btrfs_root_is_snapshot" = 'true' ]; then
-        echo "creating initial snapper config ..."
-        # we can't call snapper here as the .snapshots subvolume
-        # already exists and snapper create-config doens't like
-        # that.
-        cp /etc/snapper/config-templates/default /etc/snapper/configs/root
-        # Change configuration to match SLES12-SP1 values
-        sed -i -e '/^TIMELINE_CREATE=/s/yes/no/' /etc/snapper/configs/root
-        sed -i -e '/^NUMBER_LIMIT=/s/50/10/'     /etc/snapper/configs/root
-
-        baseUpdateSysConfig /etc/sysconfig/snapper SNAPPER_CONFIGS root
-fi
 
 
 #=====================================


### PR DESCRIPTION
Remove outdated config.sh customization based on sed edit of now relocated "default" template file containing a `root` config.

Fixes #177

- /etc/snapper/config-templates/default moved to:
- /usr/share/snapper/config-templates/default The latter is now owned by the libsnapper7 package.