### PR TITLE
Failed to start JeOS First Boot Wizard - create system snapshot #177

### DIFF
--- a/config.sh
+++ b/config.sh
@@ -6,7 +6,9 @@
 # activation or deactivation of certain services (insserv). The call is not
 # made until after the switch to the image has been made with chroot.
 
-# https://osinside.github.io/kiwi/working_with_kiwi/shell_scripts.html
+# https://osinside.github.io/kiwi/concept_and_workflow/shell_scripts.html
+# "... usually used to apply a permanent and final change of data in the root tree,
+# such as modifying a package-specific config file."
 
 # Functions...
 #--------------------------------------
@@ -92,19 +94,8 @@ rm -rf /usr/share/doc/manual/*
 #=====================================
 # Configure snapper
 #-------------------------------------
-if [ "$kiwi_btrfs_root_is_snapshot" = 'true' ]; then
-        echo "creating initial snapper config ..."
-        # we can't call snapper here as the .snapshots subvolume
-        # already exists and snapper create-config doens't like
-        # that.
-        cp /etc/snapper/config-templates/default /etc/snapper/configs/root
-        # Change configuration to match SLES12-SP1 values
-        sed -i -e '/^TIMELINE_CREATE=/s/yes/no/' /etc/snapper/configs/root
-        sed -i -e '/^NUMBER_LIMIT=/s/50/10/'     /etc/snapper/configs/root
-
-        baseUpdateSysConfig /etc/sysconfig/snapper SNAPPER_CONFIGS root
-fi
-
+echo "Enabling snapper config ..."
+baseUpdateSysConfig /etc/sysconfig/snapper SNAPPER_CONFIGS root
 
 #=====================================
 # Enable chrony if installed

--- a/root/etc/snapper/configs/root
+++ b/root/etc/snapper/configs/root
@@ -1,0 +1,64 @@
+
+# subvolume to snapshot
+SUBVOLUME="/"
+
+# filesystem type
+FSTYPE="btrfs"
+
+
+# btrfs qgroup for space aware cleanup algorithms
+QGROUP="1/0"
+
+
+# fraction or absolute size of the filesystems space the snapshots may use
+SPACE_LIMIT="0.5"
+
+# fraction or absolute size of the filesystems space that should be free
+FREE_LIMIT="0.2"
+
+
+# users and groups allowed to work with config
+ALLOW_USERS=""
+ALLOW_GROUPS=""
+
+# sync users and groups from ALLOW_USERS and ALLOW_GROUPS to .snapshots
+# directory
+SYNC_ACL="no"
+
+
+# start comparing pre- and post-snapshot in background after creating
+# post-snapshot
+BACKGROUND_COMPARISON="yes"
+
+
+# run daily number cleanup
+NUMBER_CLEANUP="yes"
+
+# limit for number cleanup
+NUMBER_MIN_AGE="3600"
+NUMBER_LIMIT="2-10"
+NUMBER_LIMIT_IMPORTANT="4-10"
+
+
+# create hourly snapshots
+TIMELINE_CREATE="no"
+
+# cleanup hourly snapshots after some time
+TIMELINE_CLEANUP="yes"
+
+# limits for timeline cleanup
+TIMELINE_MIN_AGE="3600"
+TIMELINE_LIMIT_HOURLY="10"
+TIMELINE_LIMIT_DAILY="10"
+TIMELINE_LIMIT_WEEKLY="0"
+TIMELINE_LIMIT_MONTHLY="10"
+TIMELINE_LIMIT_QUARTERLY="0"
+TIMELINE_LIMIT_YEARLY="10"
+
+
+# cleanup empty pre-post-pairs
+EMPTY_PRE_POST_CLEANUP="yes"
+
+# limits for empty pre-post-pair cleanup
+EMPTY_PRE_POST_MIN_AGE="3600"
+


### PR DESCRIPTION
Remove outdated config.sh customization based on sed edit of relocated "default" template file containing a `root` config.
- /etc/snapper/config-templates/default moved to:
- /usr/share/snapper/config-templates/default The latter is now owned by the libsnapper7 package. Add snapper 'root' default config via kiwi.ng overlay tree. Configure snapper sysconfig file to use the 'root' config.

Fixes #177 

---

Squashed variant of draft predecessor #199