### PR TITLE
Remove Leap 15.5 profiles #197

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,7 +57,7 @@ e.g., 15 GB free space, Python version, etc.
 It is recommended to use at least Kiwi-ng v10.2.13 to build our [Core Profiles](#core-profiles).
 
 Given our profiles' target OSs are exclusively 'Built on openSUSE',
-a vanilla openSUSE Leap 15.5/6 instance is recommended if not using the kiwi-ng boxbuild method.
+a vanilla openSUSE Leap 15.6 instance is recommended if not using the kiwi-ng boxbuild method.
 But if the newer kiwi-ng boxbuild method in "Building on any linux host... " is used,
 any relatively modern linux system can be used to build the installer.
 
@@ -133,7 +133,7 @@ Or go with the explicit version 3.x of pip:
 ```
 The rest remains the same (make sure to consider the memory and CPU defaults mentioned above)
 ```shell
-./kiwi-env/bin/kiwi-ng --profile=Leap15.5.x86_64 --type oem \
+./kiwi-env/bin/kiwi-ng --profile=Leap15.6.x86_64 --type oem \
   system boxbuild --box leap -- --description ./ --target-dir ./images
 ```
 
@@ -141,15 +141,15 @@ The rest remains the same (make sure to consider the memory and CPU defaults men
 This was the preferred method before the above kiwi-ng boxbuild capability existed.
 
 #### kiwi-ng install
-For an openSUSE Leap 15.5/6 OS from kiwi-ng's doc [Installation](https://osinside.github.io/kiwi/installation.html#installation) section we have:
+For an openSUSE Leap 15.6 OS from kiwi-ng's doc [Installation](https://osinside.github.io/kiwi/installation.html#installation) section we have:
 
 #### x86_64 host for x86_64 profiles
 Any x86_64 machine, keeping in mind that building an installer is computationally expensive,
 so systems with a decent-sized CPU/RAM combination released in the last 5-7 years is recommended.
 
-##### Leap 15.5/6 host
+##### Leap 15.6 host
 The openSUSE host version should ideally be at least the version of the target profile.
-Since Leap 15.5/6 ships with a default `python 3.6x` it is necessary to install a higher python version (e.g., `3.11`):
+Since Leap 15.6 ships with a default `python 3.6x` it is necessary to install a higher python version (e.g., `3.11`):
 
 ```shell
 sudo zypper in python311
@@ -157,13 +157,7 @@ sudo zypper in python311
 
 then add the required repository:
 
-for 15.5:
-
-```shell
-sudo zypper addrepo http://download.opensuse.org/repositories/Virtualization:/Appliances:/Builder/openSUSE_Leap_15.5/ appliance-builder
-```
-
-or for 15.6
+for 15.6
 
 ```shell
 sudo zypper addrepo https://download.opensuse.org/repositories/Virtualization:/Appliances:/Builder/openSUSE_Leap_15.6/ appliance-builder
@@ -177,7 +171,7 @@ sudo zypper install python3-kiwi btrfsprogs gfxboot qemu-tools gptfdisk e2fsprog
 
 #### AArch64 host (e.g., a Pi4) for AArch64 profiles
 See [HCL:Raspberry Pi4](https://en.opensuse.org/HCL:Raspberry_Pi4).
-Install, for example, an appliance JeOS Leap 15.5/6 image as the host OS.
+Install, for example, an appliance JeOS Leap 15.6 image as the host OS.
 Enabling USB boot on older Pi4 systems will allow for the use of, for example,
 an SSD as the system drive which will massively speed up installer building.
 See [Pi4 USB boot](#pi4-usb-boot).
@@ -195,7 +189,7 @@ For more information about using the most recent kernels see
 
 #### Root disk LUKS encryption
 If you want to enable LUKS encryption of the Root disk (where Rockstor is installed),
-uncomment the relevant parameters available as example in the **Leap15.5.x86_64** profile.
+uncomment the relevant parameters available as example in the **Leap15.6.x86_64** profile.
 This will enable `LUKS2` encryption and utilize PBKDF2, as grub does not yet support the more recent `argon2id` algorithm.
 
 N.B.: The `luksformat` parameter's preceding hyphens have to be escaped to exist as a comment.

--- a/config.sh
+++ b/config.sh
@@ -142,30 +142,6 @@ sed -i 's/https:\/\/www.opensuse.org/https:\/\/rockstor.com/g' /usr/lib/os-relea
 sed -i 's/^DOCUMENTATION_URL.*/DOCUMENTATION_URL="https:\/\/rockstor.com\/docs"/' /usr/lib/os-release
 
 #======================================
-# Configure Raspberry Pi specifics
-# from: https://build.opensuse.org/package/view_file/openSUSE:Factory:ToTest/kiwi-templates-JeOS/config.sh
-#--------------------------------------
-if [[ "$kiwi_profiles" == *"Leap15.3.RaspberryPi4"* ]]; then
-  # Also show WLAN interfaces in /etc/issue
-  baseUpdateSysConfig /etc/sysconfig/issue-generator NETWORK_INTERFACE_REGEX '^[bew]'
-
-  # Add necessary kernel modules to initrd (will disappear with bsc#1084272)
-  echo 'add_drivers+=" bcm2835_dma dwc2 "' > /etc/dracut.conf.d/raspberrypi_modules.conf
-
-  # Work around network issues
-  # Use tabs, "<<-" strips tabs, but no other whitespace!
-  cat > /etc/modprobe.d/50-rpi3.conf <<-EOF
-# Prevent too many page allocations (bsc#1012449)
-options smsc95xx turbo_mode=N
-EOF
-  # Use tabs, "<<-" strips tabs, but no other whitespace!
-  cat > /usr/lib/sysctl.d/50-rpi3.conf <<-EOF
-# Avoid running out of DMA pages for smsc95xx (bsc#1012449)
-vm.min_free_kbytes = 2048
-EOF
-fi
-
-#======================================
 # Apply grub config
 # Setup Grub Distributor option
 #--------------------------------------

--- a/rockstor.kiwi
+++ b/rockstor.kiwi
@@ -5,9 +5,9 @@
 <!-- For reference see: -->
 <!-- https://en.opensuse.org/Portal:JeOS -->
 <!-- https://documentation.suse.com/kiwi/9/single-html/kiwi/index.html -->
-<!-- https://build.opensuse.org/package/show/openSUSE:Leap:15.5/kiwi-templates-Minimal -->
-<!-- https://build.opensuse.org/package/show/openSUSE:Leap:15.5:Images/kiwi-templates-Minimal -->
-<!-- https://build.opensuse.org/package/show/openSUSE:Leap:15.5:Images/JeOS -->
+<!-- https://build.opensuse.org/package/show/openSUSE:Leap:15.6/kiwi-templates-Minimal -->
+<!-- https://build.opensuse.org/package/show/openSUSE:Leap:15.6:Images/kiwi-templates-Minimal -->
+<!-- https://build.opensuse.org/package/show/openSUSE:Leap:15.6:Images/JeOS -->
 <!-- OBS-Profiles: @BUILD_FLAVOR@ -->
 <image schemaversion="8.3" name="Rockstor-NAS">
     <description type="system">
@@ -21,9 +21,6 @@
         <!-- For preferences, drivers, repository, packages, and users elements -->
         <!-- https://osinside.github.io/kiwi/working_with_images/build_with_profiles.html -->
         <!-- N.B. can inherit one profile within another via requires profile="" -->
-        <profile name="Leap15.5.x86_64" description="Rockstor built on openSUSE Leap 15.5 x86_64" arch="x86_64"/>
-        <profile name="Leap15.5.RaspberryPi4" description="Rockstor built on openSUSE Leap 15.5 Raspberry_Pi" arch="aarch64"/>
-        <profile name="Leap15.5.ARM64EFI" description="Rockstor built on openSUSE Leap 15.5 ARM64 EFI/VM/Ten64" arch="aarch64"/>
         <profile name="Leap15.6.x86_64" description="Rockstor built on openSUSE Leap 15.6 x86_64" arch="x86_64"/>
         <profile name="Leap15.6.RaspberryPi4" description="Rockstor built on openSUSE Leap 15.6 Raspberry_Pi" arch="aarch64"/>
         <profile name="Leap15.6.ARM64EFI" description="Rockstor built on openSUSE Leap 15.6 ARM64 EFI/VM/Ten64" arch="aarch64"/>
@@ -32,7 +29,7 @@
         <profile name="Tumbleweed.RaspberryPi4" description="Rockstor built on openSUSE Tumbleweed Raspberry_Pi" arch="aarch64"/>
         <profile name="Tumbleweed.ARM64EFI" description="Rockstor built on openSUSE Tumbleweed ARM64 EFI/VM/Ten64" arch="aarch64"/>
     </profiles>
-    <preferences profiles="Leap15.5.x86_64,Leap15.6.x86_64,Slowroll.x86_64,Tumbleweed.x86_64">
+    <preferences profiles="Leap15.6.x86_64,Slowroll.x86_64,Tumbleweed.x86_64">
         <version>5.0.15-0</version>
         <packagemanager>zypper</packagemanager>
         <locale>en_GB</locale>
@@ -76,7 +73,7 @@
             </oemconfig>
         </type>
     </preferences>
-    <preferences profiles="Leap15.5.RaspberryPi4,Leap15.6.RaspberryPi4,Tumbleweed.RaspberryPi4">
+    <preferences profiles="Leap15.6.RaspberryPi4,Tumbleweed.RaspberryPi4">
         <version>5.0.15-0</version>
         <packagemanager>zypper</packagemanager>
         <locale>en_GB</locale>
@@ -107,7 +104,7 @@
             </oemconfig>
         </type>
     </preferences>
-    <preferences profiles="Leap15.5.ARM64EFI,Leap15.6.ARM64EFI,Tumbleweed.ARM64EFI">
+    <preferences profiles="Leap15.6.ARM64EFI,Tumbleweed.ARM64EFI">
         <version>5.0.15-0</version>
         <packagemanager>zypper</packagemanager>
         <locale>en_GB</locale>
@@ -144,9 +141,6 @@
     </users>
     <!-- https://en.opensuse.org/Package_repositories -->
     <!-- Alias repo-oss Name="Main Repository" in JeOS -->
-    <repository type="rpm-md" alias="Leap_15_5" imageinclude="true" profiles="Leap15.5.x86_64,Leap15.5.RaspberryPi4,Leap15.5.ARM64EFI">
-        <source path="obs://openSUSE:Leap:15.5/standard"/>
-    </repository>
     <repository type="rpm-md" alias="Leap_15_6" imageinclude="true" profiles="Leap15.6.x86_64,Leap15.6.RaspberryPi4,Leap15.6.ARM64EFI">
         <source path="obs://openSUSE:Leap:15.6/standard"/>
     </repository>
@@ -160,9 +154,6 @@
         <source path="https://download.opensuse.org/ports/aarch64/tumbleweed/repo/oss/"/>
     </repository>
     <!-- Alias repo-update Name="Main Update Repository" or "openSUSE-Tumbleweed-Update" in JeOS -->
-    <repository type="rpm-md" alias="Leap_15_5_Updates" imageinclude="true" profiles="Leap15.5.x86_64,Leap15.5.RaspberryPi4,Leap15.5.ARM64EFI">
-        <source path="https://download.opensuse.org/update/leap/15.5/oss/"/>
-    </repository>
     <repository type="rpm-md" alias="Leap_15_6_Updates" imageinclude="true" profiles="Leap15.6.x86_64,Leap15.6.RaspberryPi4,Leap15.6.ARM64EFI">
         <source path="https://download.opensuse.org/update/leap/15.6/oss/"/>
     </repository>
@@ -180,12 +171,6 @@
     <!-- Leap 15.3+ profiles only - repos are multi architecture -->
     <!-- Not included in image as auto added by installed system. -->
     <!-- Used during image build to capture updates at time of installer build -->
-    <repository type="rpm-md" alias="repo-backports-update" profiles="Leap15.5.x86_64,Leap15.5.RaspberryPi4,Leap15.5.ARM64EFI">
-        <source path="https://download.opensuse.org/update/leap/15.5/backports/"/>
-    </repository>
-    <repository type="rpm-md" alias="repo-sle-update" profiles="Leap15.5.x86_64,Leap15.5.RaspberryPi4,Leap15.5.ARM64EFI">
-        <source path="https://download.opensuse.org/update/leap/15.5/sle/"/>
-    </repository>
     <repository type="rpm-md" alias="repo-backports-update" profiles="Leap15.6.x86_64,Leap15.6.RaspberryPi4,Leap15.6.ARM64EFI">
         <source path="https://download.opensuse.org/update/leap/15.6/backports/"/>
     </repository>
@@ -195,9 +180,6 @@
     <!-- open H264 repos: -->
     <!-- https://news.opensuse.org/2023/01/24/opensuse-simplifies-codec-install/ -->
     <!-- https://codecs.opensuse.org/openh264/ -->
-    <repository type="rpm-md" alias="repo-openh264" imageinclude="true" profiles="Leap15.5.x86_64,Leap15.5.RaspberryPi4,Leap15.5.ARM64EFI">
-        <source path="http://codecs.opensuse.org/openh264/openSUSE_Leap"/>
-    </repository>
     <repository type="rpm-md" alias="repo-openh264" imageinclude="true" profiles="Leap15.6.x86_64,Leap15.6.RaspberryPi4,Leap15.6.ARM64EFI">
         <source path="http://codecs.opensuse.org/openh264/openSUSE_Leap"/>
     </repository>
@@ -207,9 +189,6 @@
     <!-- Virtualization_Appliances_Builder repos: -->
     <!-- Latest Kiwi-ng & Dracut helpers:  -->
     <!-- https://build.opensuse.org/project/show/Virtualization:Appliances:Builder -->
-    <repository type="rpm-md" alias="Virtualization_Appliances_Builder" imageinclude="true" profiles="Leap15.5.x86_64,Leap15.5.RaspberryPi4,Leap15.5.ARM64EFI">
-        <source path="https://download.opensuse.org/repositories/Virtualization:/Appliances:/Builder/openSUSE_Leap_15.5/"/>
-    </repository>
     <repository type="rpm-md" alias="Virtualization_Appliances_Builder" imageinclude="true" profiles="Leap15.6.x86_64,Leap15.6.RaspberryPi4,Leap15.6.ARM64EFI">
         <source path="https://download.opensuse.org/repositories/Virtualization:/Appliances:/Builder/openSUSE_Leap_15.6/"/>
     </repository>
@@ -223,9 +202,6 @@
     <!--    </repository> -->
     <!-- Resource Rockstor Testing channel during installer build only -->
     <!-- Rockstor repos are multi-arch from 15.4 onwards -->
-    <repository type="rpm-md" alias="Rockstor-Testing" profiles="Leap15.5.x86_64,Leap15.5.RaspberryPi4,Leap15.5.ARM64EFI">
-        <source path="http://updates.rockstor.com:8999/rockstor-testing/leap/15.5/"/>
-    </repository>
     <repository type="rpm-md" alias="Rockstor-Testing" profiles="Leap15.6.x86_64,Leap15.6.RaspberryPi4,Leap15.6.ARM64EFI">
         <source path="http://updates.rockstor.com:8999/rockstor-testing/leap/15.6/"/>
     </repository>
@@ -239,9 +215,6 @@
     <!-- Rockstor home repo on OBS for Leap 15.3 + now hosts dual arch shellinabox -->
     <!-- Maintain lower priority to upstream in case shellinabox is added there -->
     <!-- https://build.opensuse.org/project/show/home:rockstor -->
-    <repository type="rpm-md" alias="home_rockstor" priority="105" imageinclude="true" profiles="Leap15.5.x86_64,Leap15.5.RaspberryPi4,Leap15.5.ARM64EFI">
-        <source path="https://download.opensuse.org/repositories/home:/rockstor/15.5/"/>
-    </repository>
     <repository type="rpm-md" alias="home_rockstor" priority="105" imageinclude="true" profiles="Leap15.6.x86_64,Leap15.6.RaspberryPi4,Leap15.6.ARM64EFI">
         <source path="https://download.opensuse.org/repositories/home:/rockstor/15.6/"/>
     </repository>
@@ -255,11 +228,8 @@
     <!-- As per https://en.opensuse.org/Archive:Making_an_openSUSE_based_distribution -->
     <!-- We are required to de/re-brand packages that have no "...branding-upstream" equivalent -->
     <!-- https://build.opensuse.org/package/show/home:rockstor:branches:Base:System/systemd-presets-branding-rockstor -->
-    <repository type="rpm-md" alias="home_rockstor_branches_Base_System" priority="97" imageinclude="true" profiles="Leap15.5.x86_64,Leap15.5.RaspberryPi4,Leap15.5.ARM64EFI">
-        <source path="https://download.opensuse.org/repositories/home:/rockstor:/branches:/Base:/System/15.5/"/>
-    </repository>
     <repository type="rpm-md" alias="home_rockstor_branches_Base_System" priority="97" imageinclude="true" profiles="Leap15.6.x86_64,Leap15.6.RaspberryPi4,Leap15.6.ARM64EFI">
-        <source path="https://download.opensuse.org/repositories/home:/rockstor:/branches:/Base:/System/15.5/"/>
+        <source path="https://download.opensuse.org/repositories/home:/rockstor:/branches:/Base:/System/15.6/"/>
     </repository>
     <repository type="rpm-md" alias="home_rockstor_branches_Base_System" priority="97" imageinclude="true" profiles="Slowroll.x86_64">
         <source path="https://download.opensuse.org/repositories/home:/rockstor:/branches:/Base:/System/openSUSE_Slowroll/"/>
@@ -276,21 +246,21 @@
     <!-- Kernel HEAD Backports -->
     <!-- https://build.opensuse.org/repositories/Kernel:HEAD:Backport -->
     <!--    <repository type="rpm-md" alias="Kernel_HEAD_Backport" imageinclude="true" -->
-    <!--                profiles="Leap15.5.x86_64,Leap15.5.RaspberryPi4,Leap15.5.ARM64EFI"> -->
+    <!--                profiles="Leap15.6.x86_64,Leap15.6.RaspberryPi4,Leap15.6.ARM64EFI"> -->
     <!--        <source path="https://download.opensuse.org/repositories/Kernel:/HEAD:/Backport/standard/"/> -->
     <!--    </repository> -->
     <!-- Kernel Stable Backports -->
     <!-- https://build.opensuse.org/project/show/Kernel:stable:Backport -->
     <!-- See also: https://rockstor.com/docs/howtos/stable_kernel_backport.html  -->
     <!--    <repository type="rpm-md" alias="Kernel_stable_Backport" imageinclude="true" -->
-    <!--                profiles="Leap15.5.x86_64,Leap15.5.RaspberryPi4,Leap15.5.ARM64EFI"> -->
+    <!--                profiles="Leap15.6.x86_64,Leap15.6.RaspberryPi4,Leap15.6.ARM64EFI"> -->
     <!--        <source path="https://download.opensuse.org/repositories/Kernel:/stable:/Backport/standard/"/> -->
     <!--    </repository>-->
     <!-- btrfs-progs backport via filesystems repo -->
     <!-- https://build.opensuse.org/project/show/filesystems -->
     <!--    <repository type="rpm-md" alias="filesystems" imageinclude="true" -->
-    <!--                profiles="Leap15.5.x86_64,Leap15.5.RaspberryPi4,Leap15.5.ARM64EFI"> -->
-    <!--        <source path="https://download.opensuse.org/repositories/filesystems/15.5/"/> -->
+    <!--                profiles="Leap15.6.x86_64,Leap15.6.RaspberryPi4,Leap15.6.ARM64EFI"> -->
+    <!--        <source path="https://download.opensuse.org/repositories/filesystems/15.6/"/> -->
     <!--    </repository> -->
     <packages type="image">
         <package name="adaptec-firmware"/> <!-- Razor AIC94xx Series SAS -->
@@ -364,7 +334,7 @@
         <!-- ROCKSTOR PACKAGE: CHANGE VERSION AS REQUIRED -->
         <package name="rockstor-5.0.15-0"/>
     </packages>
-    <packages type="image" profiles="Leap15.5.RaspberryPi4,Leap15.6.RaspberryPi4,Tumbleweed.RaspberryPi4">
+    <packages type="image" profiles="Leap15.6.RaspberryPi4,Tumbleweed.RaspberryPi4">
         <package name="raspberrypi-eeprom" arch="aarch64"/>
         <package name="raspberrypi-firmware" arch="aarch64"/>
         <package name="raspberrypi-firmware-config" arch="aarch64"/>

--- a/vagrant_env/Vagrantfile
+++ b/vagrant_env/Vagrantfile
@@ -34,14 +34,13 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
         v.vm.hostname = "rockstor-installer"
         if PROFILE == "x86_64" then
             # One can switch back to bento in case OpenSUSE is broken (typically issues around VB guest additions
-            v.vm.box = 'opensuse/Leap-15.3.x86_64'
-		# if a specific version should be used:
-			# v.vm.box_version = '15.3.9.361'
-            # v.vm.box = 'bento/opensuse-leap-15.3'
-		# if a specific version should be used:
-			# v.vm.box_version = '202112.23.0'
+            # https://portal.cloud.hashicorp.com/vagrant/discover?query=opensuse
+            v.vm.box = 'opensuse/Leap-15.6.x86_64'
+		    # if a specific version should be used:
+			# v.vm.box_version = '15.6.13.356'
         else
-            v.vm.box = 'opensuse/Leap-15.3.aarch64'
+            # https://portal.cloud.hashicorp.com/vagrant/discover?architectures=arm64&query=opensuse
+            v.vm.box = 'bento/opensuse-leap-15.6'
         end
 
         # Provider specific variables

--- a/vagrant_env/initial_prep.sh
+++ b/vagrant_env/initial_prep.sh
@@ -24,7 +24,7 @@ sudo zypper --gpg-auto-import-keys refresh appliance-builder
 sudo zypper -n install python311-kiwi btrfsprogs gfxboot qemu-tools gptfdisk e2fsprogs squashfs xorriso dosfstools binutils xz
 
 echo "================================================="
-echo "verify kiwi-ng version. 10.1 or higher"
+echo "verify kiwi-ng version. v10.2.13 or higher"
 echo "================================================="
 sudo kiwi-ng --version
 


### PR DESCRIPTION
OpenSUSE Leap 15.5 is now EOL.
- Update/remove all 15.5 profile references.
- Includes fix re 15.5 repo use in a 15.6 profile entry.
- N.B. Untested related updates to vagrant instructions/scripts.

Fixes #197 