### PR TITLE
Add SELinux tools, plus zypper config tweaks #200

### DIFF
--- a/config.sh
+++ b/config.sh
@@ -153,30 +153,6 @@ sed -i 's/^DOCUMENTATION_URL.*/DOCUMENTATION_URL="https:\/\/rockstor.com\/docs"/
 
 #======================================
 # Apply grub configs
-#======================================
-# Default kernel boot options
-#--------------------------------------
-# Common to all profiles
-cmdline=('plymouth.enable=0')
-# Machine targets
-case "${kiwi_profiles}" in
-    *x86_64) cmdline+=('nomodeset') ;;
-    *RaspberryPi4) cmdline+=('console=ttyS0,115200' 'console=tty') ;;
-    *ARM64EFI) cmdline+=('earlycon') ;;
-esac
-# SELinux config - if installed
-if [[ -e /etc/selinux/config ]]; then
-    # `enforcing=0` for permissive (default), 1 for enforcing
-    cmdline+=('security=selinux' 'selinux=1')
-    sed -i -e 's|^SELINUX=.*|SELINUX=permissive|g' \
-           -e 's|^SELINUXTYPE=.*|SELINUXTYPE=targeted|g' \
-           "/etc/selinux/config"
-fi
-if [ -e /etc/default/grub ]; then
-    sed -i "s#^GRUB_CMDLINE_LINUX_DEFAULT=.*\$#GRUB_CMDLINE_LINUX_DEFAULT=\"${cmdline[*]}\"#" /etc/default/grub
-fi
-
-#======================================
 # Setup Grub Distributor option
 #--------------------------------------
 echo >> /etc/default/grub

--- a/config.sh
+++ b/config.sh
@@ -157,7 +157,7 @@ sed -i 's/^DOCUMENTATION_URL.*/DOCUMENTATION_URL="https:\/\/rockstor.com\/docs"/
 # Default kernel boot options
 #--------------------------------------
 # Common to all profiles
-cmdline=('plymouth.enable=0' 'rd.kiwi.oem.maxdisk=5000G')
+cmdline=('plymouth.enable=0')
 # Machine targets
 case "${kiwi_profiles}" in
   *x86_64) cmdline+=('nomodeset') ;;

--- a/config.sh
+++ b/config.sh
@@ -10,7 +10,9 @@
 # "... usually used to apply a permanent and final change of data in the root tree,
 # such as modifying a package-specific config file."
 
+#======================================
 # Functions...
+# https://osinside.github.io/kiwi/concept_and_workflow/shell_scripts.html#profile-environment-variables
 #--------------------------------------
 test -f /.kconfig && . /.kconfig
 test -f /.profile && . /.profile

--- a/config.sh
+++ b/config.sh
@@ -160,20 +160,20 @@ sed -i 's/^DOCUMENTATION_URL.*/DOCUMENTATION_URL="https:\/\/rockstor.com\/docs"/
 cmdline=('plymouth.enable=0')
 # Machine targets
 case "${kiwi_profiles}" in
-  *x86_64) cmdline+=('nomodeset') ;;
-	*RaspberryPi4) cmdline+=('console=ttyS0,115200' 'console=tty') ;;
-	*ARM64EFI) cmdline+=('earlycon') ;;
+    *x86_64) cmdline+=('nomodeset') ;;
+    *RaspberryPi4) cmdline+=('console=ttyS0,115200' 'console=tty') ;;
+    *ARM64EFI) cmdline+=('earlycon') ;;
 esac
 # SELinux config - if installed
 if [[ -e /etc/selinux/config ]]; then
-  # `enforcing=0` for permissive (default), 1 for enforcing
-	cmdline+=('security=selinux' 'selinux=1')
-	sed -i -e 's|^SELINUX=.*|SELINUX=permissive|g' \
-	       -e 's|^SELINUXTYPE=.*|SELINUXTYPE=targeted|g' \
-	       "/etc/selinux/config"
+    # `enforcing=0` for permissive (default), 1 for enforcing
+    cmdline+=('security=selinux' 'selinux=1')
+    sed -i -e 's|^SELINUX=.*|SELINUX=permissive|g' \
+           -e 's|^SELINUXTYPE=.*|SELINUXTYPE=targeted|g' \
+           "/etc/selinux/config"
 fi
 if [ -e /etc/default/grub ]; then
-	sed -i "s#^GRUB_CMDLINE_LINUX_DEFAULT=.*\$#GRUB_CMDLINE_LINUX_DEFAULT=\"${cmdline[*]}\"#" /etc/default/grub
+    sed -i "s#^GRUB_CMDLINE_LINUX_DEFAULT=.*\$#GRUB_CMDLINE_LINUX_DEFAULT=\"${cmdline[*]}\"#" /etc/default/grub
 fi
 
 #======================================

--- a/images.sh
+++ b/images.sh
@@ -1,0 +1,34 @@
+#!/bin/bash
+
+# https://osinside.github.io/kiwi/concept_and_workflow/shell_scripts.html
+# "Executed at the beginning of the image creation process.
+# It runs in the same image root tree created by the prepare step,
+# but it is invoked whenever an image needs to be created from that root tree.
+# It is normally used to apply image type specific changes to the root tree,
+# such as a modification to a config file that must be done when building a live iso,
+# but not when building a virtual disk image."
+
+# https://osinside.github.io/kiwi/concept_and_workflow.html#the-create-step
+# "At the beginning of the image creation process the script named images.sh is executed (if present)."
+
+#======================================
+# SELinux config - if installed
+#--------------------------------------
+# `enforcing=0` for permissive (default), 1 for enforcing
+selinuxcmdline=('security=selinux' 'selinux=1')
+# SELinux kernel options added to rockstor.kiwi image.preferences.type kernelcmdline= entries.
+if [[ -e /etc/selinux/config ]]; then
+    # Grub kernel cmdline additions
+    if [[ -e /etc/default/grub ]]; then
+        sed -i "s|^GRUB_CMDLINE_LINUX_DEFAULT=\"|&${selinuxcmdline[*]} |" /etc/default/grub
+    fi
+    # Sysconfig bootloader cmdline additions (installer boot)
+    if [[ -e /etc/sysconfig/bootloader ]]; then
+        sed -i "s|^DEFAULT_APPEND=\"|&${selinuxcmdline[*]} |" /etc/sysconfig/bootloader
+        sed -i "s|^FAILSAFE_APPEND=\"|&${selinuxcmdline[*]} |" /etc/sysconfig/bootloader
+    fi
+    # SELinux config
+    sed -i -e 's|^SELINUX=.*|SELINUX=permissive|g' \
+           -e 's|^SELINUXTYPE=.*|SELINUXTYPE=targeted|g' \
+           "/etc/selinux/config"
+fi

--- a/pre_disk_sync.sh
+++ b/pre_disk_sync.sh
@@ -1,15 +1,8 @@
 #!/bin/bash
 
 # https://osinside.github.io/kiwi/concept_and_workflow/shell_scripts.html
-# "Executed at the beginning of the image creation process.
-# It runs in the same image root tree created by the prepare step,
-# but it is invoked whenever an image needs to be created from that root tree.
-# It is normally used to apply image type specific changes to the root tree,
-# such as a modification to a config file that must be done when building a live iso,
-# but not when building a virtual disk image."
-
-# https://osinside.github.io/kiwi/concept_and_workflow.html#the-create-step
-# "At the beginning of the image creation process the script named images.sh is executed (if present)."
+# "The pre_disk_sync.sh can be used to change content of the root tree
+# as a last action before the sync to the disk image is performed."
 
 #======================================
 # SELinux config - if installed

--- a/pre_disk_sync.sh
+++ b/pre_disk_sync.sh
@@ -11,17 +11,25 @@
 selinuxcmdline=('security=selinux' 'selinux=1')
 # SELinux kernel options added to rockstor.kiwi image.preferences.type kernelcmdline= entries.
 if [[ -e /etc/selinux/config ]]; then
+    # SELinux config
+    sed -i -e 's|^SELINUX=.*|SELINUX=permissive|g' \
+           -e 's|^SELINUXTYPE=.*|SELINUXTYPE=targeted|g' \
+           "/etc/selinux/config"
+    echo "-- /etc/selinux/config updated -----"
     # Grub kernel cmdline additions
     if [[ -e /etc/default/grub ]]; then
         sed -i "s|^GRUB_CMDLINE_LINUX_DEFAULT=\"|&${selinuxcmdline[*]} |" /etc/default/grub
+        echo "-- /etc/default/grub updated -------"
     fi
     # Sysconfig bootloader cmdline additions (installer boot)
     if [[ -e /etc/sysconfig/bootloader ]]; then
         sed -i "s|^DEFAULT_APPEND=\"|&${selinuxcmdline[*]} |" /etc/sysconfig/bootloader
         sed -i "s|^FAILSAFE_APPEND=\"|&${selinuxcmdline[*]} |" /etc/sysconfig/bootloader
+        echo "-- /etc/sysconfig/bootloader updated"
     fi
-    # SELinux config
-    sed -i -e 's|^SELINUX=.*|SELINUX=permissive|g' \
-           -e 's|^SELINUXTYPE=.*|SELINUXTYPE=targeted|g' \
-           "/etc/selinux/config"
+    # Update kiwi-ng's bootoptions config file used by dracut
+    if [[ -e /config.bootoptions ]]; then
+        sed -i "1 s|.|${selinuxcmdline[*]} &|" /config.bootoptions
+        echo "-- /config.bootoptions updated -----"
+    fi
 fi

--- a/rockstor.kiwi
+++ b/rockstor.kiwi
@@ -351,6 +351,7 @@
         <package name="python311-semanage"/>  <!-- 1 pkg 378 KB requried for semanage -->
         <package name="python311-selinux"/>  <!-- 1 pkg 550 KB requried for semanage -->
         <package name="policycoreutils-python-utils"/>  <!-- 59 pkg 70.4 MB - semanage plus bloat -->
+        <package name="selinux-autorelabel"/>  <!-- 1 pkg 28 KB early boot relabelling -->
     </packages>
     <packages type="image" profiles="Leap15.6.RaspberryPi4,Tumbleweed.RaspberryPi4">
         <package name="raspberrypi-eeprom" arch="aarch64"/>

--- a/rockstor.kiwi
+++ b/rockstor.kiwi
@@ -46,8 +46,8 @@
         <!-- note: change luks Pass Phrase -->
         <!--        luks="c00l_Pa$$Phra$e" -->
         <!--        luks_version="luks2" -->
-        <!-- See config.sh for kernel cmdline via grub configuration -->
-        <type image="oem" primary="true" initrd_system="dracut" filesystem="btrfs" fsmountoptions="noatime" firmware="efi" installiso="true" bootpartition="false" devicepersistency="by-label" btrfs_root_is_subvolume="true" btrfs_root_is_snapper_snapshot="true" btrfs_quota_groups="false" efipartsize="64">
+        <!-- N.B. kernelcmdline for installer - config.sh re-sets for installed instance -->
+        <type image="oem" primary="true" initrd_system="dracut" filesystem="btrfs" fsmountoptions="noatime" firmware="efi" installiso="true" kernelcmdline="nomodeset plymouth.enable=0 rd.kiwi.oem.maxdisk=5000G" bootpartition="false" devicepersistency="by-label" btrfs_root_is_subvolume="true" btrfs_root_is_snapper_snapshot="true" btrfs_quota_groups="false" efipartsize="64">
             <bootloader name="grub2" bls="false"/>
             <!-- For full disk LUKS encryption uncomment below entries -->
             <!-- PBKDF2 is required for grub to recognize encryption -->
@@ -86,8 +86,8 @@
         <bootloader-theme>starfield</bootloader-theme>
         <!-- firmware="efi" See https://github.com/OSInside/kiwi/issues/1428 re AArch64 -->
         <!-- Re AArch64: https://github.com/OSInside/kiwi/issues/1491 -->
-        <!-- See config.sh for kernel cmdline via grub configuration -->
-        <type image="oem" initrd_system="dracut" filesystem="btrfs" fsmountoptions="noatime,compress=lzo" firmware="efi" bootpartition="false" devicepersistency="by-uuid" btrfs_root_is_subvolume="true" btrfs_root_is_snapper_snapshot="true" btrfs_quota_groups="false" efipartsize="64" editbootinstall="editbootinstall_rpi.sh">
+        <!-- N.B. kernelcmdline for installer - config.sh re-sets for installed instance -->
+        <type image="oem" initrd_system="dracut" filesystem="btrfs" fsmountoptions="noatime,compress=lzo" firmware="efi" kernelcmdline="plymouth.enable=0 rd.kiwi.oem.maxdisk=5000G console=ttyS0,115200 console=tty" bootpartition="false" devicepersistency="by-uuid" btrfs_root_is_subvolume="true" btrfs_root_is_snapper_snapshot="true" btrfs_quota_groups="false" efipartsize="64" editbootinstall="editbootinstall_rpi.sh">
             <bootloader name="grub2" bls="false"/>
             <systemdisk>
                 <volume name="home"/>
@@ -118,8 +118,8 @@
         <bootloader-theme>starfield</bootloader-theme>
         <!-- firmware="efi" See https://github.com/OSInside/kiwi/issues/1428 re AArch64 -->
         <!-- Re AArch64: https://github.com/OSInside/kiwi/issues/1491 -->
-        <!-- See config.sh for kernel cmdline via grub configuration -->
-        <type image="oem" initrd_system="dracut" filesystem="btrfs" fsmountoptions="noatime,compress=lzo" firmware="efi" bootpartition="false" devicepersistency="by-uuid" btrfs_root_is_subvolume="true" btrfs_root_is_snapper_snapshot="true" btrfs_quota_groups="false" efipartsize="64" format="qcow2">
+        <!-- N.B. kernelcmdline for installer - config.sh re-sets for installed instance -->
+        <type image="oem" initrd_system="dracut" filesystem="btrfs" fsmountoptions="noatime,compress=lzo" firmware="efi" kernelcmdline="plymouth.enable=0 rd.kiwi.oem.maxdisk=5000G earlycon" bootpartition="false" devicepersistency="by-uuid" btrfs_root_is_subvolume="true" btrfs_root_is_snapper_snapshot="true" btrfs_quota_groups="false" efipartsize="64" format="qcow2">
             <bootloader name="grub2" bls="false"/>
             <systemdisk>
                 <volume name="home"/>

--- a/rockstor.kiwi
+++ b/rockstor.kiwi
@@ -351,7 +351,6 @@
         <package name="python311-semanage"/>  <!-- 1 pkg 378 KB requried for semanage -->
         <package name="python311-selinux"/>  <!-- 1 pkg 550 KB requried for semanage -->
         <package name="policycoreutils-python-utils"/>  <!-- 59 pkg 70.4 MB - semanage plus bloat -->
-        <package name="selinux-autorelabel"/>  <!-- 1 pkg 28 KB early boot relabelling -->
     </packages>
     <packages type="image" profiles="Leap15.6.RaspberryPi4,Tumbleweed.RaspberryPi4">
         <package name="raspberrypi-eeprom" arch="aarch64"/>

--- a/rockstor.kiwi
+++ b/rockstor.kiwi
@@ -46,7 +46,7 @@
         <!-- note: change luks Pass Phrase -->
         <!--        luks="c00l_Pa$$Phra$e" -->
         <!--        luks_version="luks2" -->
-        <!-- N.B. kernelcmdline may be modified by images.sh -->
+        <!-- N.B. kernelcmdline may be modified by pre_disk_sync.sh -->
         <type image="oem" primary="true" initrd_system="dracut" filesystem="btrfs" fsmountoptions="noatime" firmware="efi" installiso="true" kernelcmdline="nomodeset plymouth.enable=0 rd.kiwi.oem.maxdisk=5000G" bootpartition="false" devicepersistency="by-label" btrfs_root_is_subvolume="true" btrfs_root_is_snapper_snapshot="true" btrfs_quota_groups="false" efipartsize="64">
             <bootloader name="grub2" bls="false"/>
             <!-- For full disk LUKS encryption uncomment below entries -->
@@ -86,7 +86,7 @@
         <bootloader-theme>starfield</bootloader-theme>
         <!-- firmware="efi" See https://github.com/OSInside/kiwi/issues/1428 re AArch64 -->
         <!-- Re AArch64: https://github.com/OSInside/kiwi/issues/1491 -->
-        <!-- N.B. kernelcmdline may be modified by images.sh -->
+        <!-- N.B. kernelcmdline may be modified by pre_disk_sync.sh -->
         <type image="oem" initrd_system="dracut" filesystem="btrfs" fsmountoptions="noatime,compress=lzo" firmware="efi" kernelcmdline="plymouth.enable=0 rd.kiwi.oem.maxdisk=5000G console=ttyS0,115200 console=tty" bootpartition="false" devicepersistency="by-uuid" btrfs_root_is_subvolume="true" btrfs_root_is_snapper_snapshot="true" btrfs_quota_groups="false" efipartsize="64" editbootinstall="editbootinstall_rpi.sh">
             <bootloader name="grub2" bls="false"/>
             <systemdisk>
@@ -118,7 +118,7 @@
         <bootloader-theme>starfield</bootloader-theme>
         <!-- firmware="efi" See https://github.com/OSInside/kiwi/issues/1428 re AArch64 -->
         <!-- Re AArch64: https://github.com/OSInside/kiwi/issues/1491 -->
-        <!-- N.B. kernelcmdline may be modified by images.sh -->
+        <!-- N.B. kernelcmdline may be modified by pre_disk_sync.sh -->
         <type image="oem" initrd_system="dracut" filesystem="btrfs" fsmountoptions="noatime,compress=lzo" firmware="efi" kernelcmdline="plymouth.enable=0 rd.kiwi.oem.maxdisk=5000G earlycon" bootpartition="false" devicepersistency="by-uuid" btrfs_root_is_subvolume="true" btrfs_root_is_snapper_snapshot="true" btrfs_quota_groups="false" efipartsize="64" format="qcow2">
             <bootloader name="grub2" bls="false"/>
             <systemdisk>

--- a/rockstor.kiwi
+++ b/rockstor.kiwi
@@ -46,6 +46,7 @@
         <!-- note: change luks Pass Phrase -->
         <!--        luks="c00l_Pa$$Phra$e" -->
         <!--        luks_version="luks2" -->
+        <!-- See config.sh for kernel cmdline via grub configuration -->
         <type image="oem" primary="true" initrd_system="dracut" filesystem="btrfs" fsmountoptions="noatime" firmware="efi" installiso="true" bootpartition="false" devicepersistency="by-label" btrfs_root_is_subvolume="true" btrfs_root_is_snapper_snapshot="true" btrfs_quota_groups="false" efipartsize="64">
             <bootloader name="grub2" bls="false"/>
             <!-- For full disk LUKS encryption uncomment below entries -->
@@ -85,6 +86,7 @@
         <bootloader-theme>starfield</bootloader-theme>
         <!-- firmware="efi" See https://github.com/OSInside/kiwi/issues/1428 re AArch64 -->
         <!-- Re AArch64: https://github.com/OSInside/kiwi/issues/1491 -->
+        <!-- See config.sh for kernel cmdline via grub configuration -->
         <type image="oem" initrd_system="dracut" filesystem="btrfs" fsmountoptions="noatime,compress=lzo" firmware="efi" bootpartition="false" devicepersistency="by-uuid" btrfs_root_is_subvolume="true" btrfs_root_is_snapper_snapshot="true" btrfs_quota_groups="false" efipartsize="64" editbootinstall="editbootinstall_rpi.sh">
             <bootloader name="grub2" bls="false"/>
             <systemdisk>
@@ -116,6 +118,7 @@
         <bootloader-theme>starfield</bootloader-theme>
         <!-- firmware="efi" See https://github.com/OSInside/kiwi/issues/1428 re AArch64 -->
         <!-- Re AArch64: https://github.com/OSInside/kiwi/issues/1491 -->
+        <!-- See config.sh for kernel cmdline via grub configuration -->
         <type image="oem" initrd_system="dracut" filesystem="btrfs" fsmountoptions="noatime,compress=lzo" firmware="efi" bootpartition="false" devicepersistency="by-uuid" btrfs_root_is_subvolume="true" btrfs_root_is_snapper_snapshot="true" btrfs_quota_groups="false" efipartsize="64" format="qcow2">
             <bootloader name="grub2" bls="false"/>
             <systemdisk>

--- a/rockstor.kiwi
+++ b/rockstor.kiwi
@@ -343,8 +343,10 @@
         <package name="restorecond"/>  <!-- 1 pkg 24 KB -->
         <package name="audit"/>  <!-- 4 pkg 777 KB -->
         <package name="selinux-policy"/>   <!-- default permissive/targeted -->
+        <package name="selinux-policy-targeted"/>   <!-- targeted base module depends on selinux-policy -->
         <package name="checkpolicy"/>  <!-- 1 pkg 2 MB -->
         <package name="python311-semanage"/>  <!-- 1 pkg 378 KB requried for semanage -->
+        <package name="python311-selinux"/>  <!-- 1 pkg 550 KB requried for semanage -->
         <package name="policycoreutils-python-utils"/>  <!-- 59 pkg 70.4 MB - semanage plus bloat -->
     </packages>
     <packages type="image" profiles="Leap15.6.RaspberryPi4,Tumbleweed.RaspberryPi4">

--- a/rockstor.kiwi
+++ b/rockstor.kiwi
@@ -46,7 +46,7 @@
         <!-- note: change luks Pass Phrase -->
         <!--        luks="c00l_Pa$$Phra$e" -->
         <!--        luks_version="luks2" -->
-        <!-- N.B. kernelcmdline for installer - config.sh re-sets for installed instance -->
+        <!-- N.B. kernelcmdline may be modified by images.sh -->
         <type image="oem" primary="true" initrd_system="dracut" filesystem="btrfs" fsmountoptions="noatime" firmware="efi" installiso="true" kernelcmdline="nomodeset plymouth.enable=0 rd.kiwi.oem.maxdisk=5000G" bootpartition="false" devicepersistency="by-label" btrfs_root_is_subvolume="true" btrfs_root_is_snapper_snapshot="true" btrfs_quota_groups="false" efipartsize="64">
             <bootloader name="grub2" bls="false"/>
             <!-- For full disk LUKS encryption uncomment below entries -->
@@ -86,7 +86,7 @@
         <bootloader-theme>starfield</bootloader-theme>
         <!-- firmware="efi" See https://github.com/OSInside/kiwi/issues/1428 re AArch64 -->
         <!-- Re AArch64: https://github.com/OSInside/kiwi/issues/1491 -->
-        <!-- N.B. kernelcmdline for installer - config.sh re-sets for installed instance -->
+        <!-- N.B. kernelcmdline may be modified by images.sh -->
         <type image="oem" initrd_system="dracut" filesystem="btrfs" fsmountoptions="noatime,compress=lzo" firmware="efi" kernelcmdline="plymouth.enable=0 rd.kiwi.oem.maxdisk=5000G console=ttyS0,115200 console=tty" bootpartition="false" devicepersistency="by-uuid" btrfs_root_is_subvolume="true" btrfs_root_is_snapper_snapshot="true" btrfs_quota_groups="false" efipartsize="64" editbootinstall="editbootinstall_rpi.sh">
             <bootloader name="grub2" bls="false"/>
             <systemdisk>
@@ -118,7 +118,7 @@
         <bootloader-theme>starfield</bootloader-theme>
         <!-- firmware="efi" See https://github.com/OSInside/kiwi/issues/1428 re AArch64 -->
         <!-- Re AArch64: https://github.com/OSInside/kiwi/issues/1491 -->
-        <!-- N.B. kernelcmdline for installer - config.sh re-sets for installed instance -->
+        <!-- N.B. kernelcmdline may be modified by images.sh -->
         <type image="oem" initrd_system="dracut" filesystem="btrfs" fsmountoptions="noatime,compress=lzo" firmware="efi" kernelcmdline="plymouth.enable=0 rd.kiwi.oem.maxdisk=5000G earlycon" bootpartition="false" devicepersistency="by-uuid" btrfs_root_is_subvolume="true" btrfs_root_is_snapper_snapshot="true" btrfs_quota_groups="false" efipartsize="64" format="qcow2">
             <bootloader name="grub2" bls="false"/>
             <systemdisk>

--- a/rockstor.kiwi
+++ b/rockstor.kiwi
@@ -46,7 +46,7 @@
         <!-- note: change luks Pass Phrase -->
         <!--        luks="c00l_Pa$$Phra$e" -->
         <!--        luks_version="luks2" -->
-        <type image="oem" primary="true" initrd_system="dracut" filesystem="btrfs" fsmountoptions="noatime" firmware="efi" installiso="true" kernelcmdline="nomodeset plymouth.enable=0 rd.kiwi.oem.maxdisk=5000G" bootpartition="false" devicepersistency="by-label" btrfs_root_is_subvolume="true" btrfs_root_is_snapper_snapshot="true" btrfs_quota_groups="false" efipartsize="64">
+        <type image="oem" primary="true" initrd_system="dracut" filesystem="btrfs" fsmountoptions="noatime" firmware="efi" installiso="true" bootpartition="false" devicepersistency="by-label" btrfs_root_is_subvolume="true" btrfs_root_is_snapper_snapshot="true" btrfs_quota_groups="false" efipartsize="64">
             <bootloader name="grub2" bls="false"/>
             <!-- For full disk LUKS encryption uncomment below entries -->
             <!-- PBKDF2 is required for grub to recognize encryption -->
@@ -85,7 +85,7 @@
         <bootloader-theme>starfield</bootloader-theme>
         <!-- firmware="efi" See https://github.com/OSInside/kiwi/issues/1428 re AArch64 -->
         <!-- Re AArch64: https://github.com/OSInside/kiwi/issues/1491 -->
-        <type image="oem" initrd_system="dracut" filesystem="btrfs" fsmountoptions="noatime,compress=lzo" firmware="efi" kernelcmdline="plymouth.enable=0 rd.kiwi.oem.maxdisk=5000G console=ttyS0,115200 console=tty" bootpartition="false" devicepersistency="by-uuid" btrfs_root_is_subvolume="true" btrfs_root_is_snapper_snapshot="true" btrfs_quota_groups="false" efipartsize="64" editbootinstall="editbootinstall_rpi.sh">
+        <type image="oem" initrd_system="dracut" filesystem="btrfs" fsmountoptions="noatime,compress=lzo" firmware="efi" bootpartition="false" devicepersistency="by-uuid" btrfs_root_is_subvolume="true" btrfs_root_is_snapper_snapshot="true" btrfs_quota_groups="false" efipartsize="64" editbootinstall="editbootinstall_rpi.sh">
             <bootloader name="grub2" bls="false"/>
             <systemdisk>
                 <volume name="home"/>
@@ -116,7 +116,7 @@
         <bootloader-theme>starfield</bootloader-theme>
         <!-- firmware="efi" See https://github.com/OSInside/kiwi/issues/1428 re AArch64 -->
         <!-- Re AArch64: https://github.com/OSInside/kiwi/issues/1491 -->
-        <type image="oem" initrd_system="dracut" filesystem="btrfs" fsmountoptions="noatime,compress=lzo" firmware="efi" kernelcmdline="plymouth.enable=0 rd.kiwi.oem.maxdisk=5000G earlycon" bootpartition="false" devicepersistency="by-uuid" btrfs_root_is_subvolume="true" btrfs_root_is_snapper_snapshot="true" btrfs_quota_groups="false" efipartsize="64" format="qcow2">
+        <type image="oem" initrd_system="dracut" filesystem="btrfs" fsmountoptions="noatime,compress=lzo" firmware="efi" bootpartition="false" devicepersistency="by-uuid" btrfs_root_is_subvolume="true" btrfs_root_is_snapper_snapshot="true" btrfs_quota_groups="false" efipartsize="64" format="qcow2">
             <bootloader name="grub2" bls="false"/>
             <systemdisk>
                 <volume name="home"/>
@@ -333,6 +333,19 @@
         <package name="ntfs-3g"/>
         <!-- ROCKSTOR PACKAGE: CHANGE VERSION AS REQUIRED -->
         <package name="rockstor-5.0.15-0"/>
+    </packages>
+    <!-- SELinux packages -->
+    <!-- See config.sh for kernel & grub configuration -->
+    <!-- Installed pkg count/size with `no-recommends` -->
+    <packages type="image" profiles="Slowroll.x86_64,Tumbleweed.x86_64,Tumbleweed.RaspberryPi4,Tumbleweed.ARM64EFI">
+        <package name="policycoreutils"/>  <!-- 3 pkg 1 MB -->
+        <package name="setools-console"/>  <!-- 3 pkg 15 MB -->
+        <package name="restorecond"/>  <!-- 1 pkg 24 KB -->
+        <package name="audit"/>  <!-- 4 pkg 777 KB -->
+        <package name="selinux-policy"/>   <!-- default permissive/targeted -->
+        <package name="checkpolicy"/>  <!-- 1 pkg 2 MB -->
+        <package name="python311-semanage"/>  <!-- 1 pkg 378 KB requried for semanage -->
+        <package name="policycoreutils-python-utils"/>  <!-- 59 pkg 70.4 MB - semanage plus bloat -->
     </packages>
     <packages type="image" profiles="Leap15.6.RaspberryPi4,Tumbleweed.RaspberryPi4">
         <package name="raspberrypi-eeprom" arch="aarch64"/>


### PR DESCRIPTION
"SELinux packages" section for Slowroll & Tumbleweed profiles. Move static kernel cmdline config to config.sh as SELinux requires selection & enablement via kernel options.

If config.sh finds `/etc/selinux/config` a permissive and targeted config is established: currently corresponding to package defaults.

Incidental Zypper config changes:
- Disable doc installation by default.
- Default to --no-recommends.

Fixes #200 
