### PR TITLE
Add SELinux tools, plus zypper config tweaks #200

### DIFF
--- a/config.sh
+++ b/config.sh
@@ -10,7 +10,9 @@
 # "... usually used to apply a permanent and final change of data in the root tree,
 # such as modifying a package-specific config file."
 
+#======================================
 # Functions...
+# https://osinside.github.io/kiwi/concept_and_workflow/shell_scripts.html#profile-environment-variables
 #--------------------------------------
 test -f /.kconfig && . /.kconfig
 test -f /.profile && . /.profile
@@ -91,6 +93,16 @@ baseSetRunlevel 3
 rm -rf /usr/share/doc/packages/*
 rm -rf /usr/share/doc/manual/*
 
+#======================================
+# Disable installing documentation
+#--------------------------------------
+sed -i 's/.*rpm.install.excludedocs.*/rpm.install.excludedocs = yes/g' /etc/zypp/zypp.conf
+
+#======================================
+# Disable recommends
+#--------------------------------------
+sed -i 's/.*solver.onlyRequires.*/solver.onlyRequires = true/g' /etc/zypp/zypp.conf
+
 #=====================================
 # Configure snapper
 #-------------------------------------
@@ -142,7 +154,7 @@ sed -i 's/https:\/\/www.opensuse.org/https:\/\/rockstor.com/g' /usr/lib/os-relea
 sed -i 's/^DOCUMENTATION_URL.*/DOCUMENTATION_URL="https:\/\/rockstor.com\/docs"/' /usr/lib/os-release
 
 #======================================
-# Apply grub config
+# Apply grub configs
 # Setup Grub Distributor option
 #--------------------------------------
 echo >> /etc/default/grub

--- a/pre_disk_sync.sh
+++ b/pre_disk_sync.sh
@@ -1,0 +1,35 @@
+#!/bin/bash
+
+# https://osinside.github.io/kiwi/concept_and_workflow/shell_scripts.html
+# "The pre_disk_sync.sh can be used to change content of the root tree
+# as a last action before the sync to the disk image is performed."
+
+#======================================
+# SELinux config - if installed
+#--------------------------------------
+# `enforcing=0` for permissive (default), 1 for enforcing
+selinuxcmdline=('security=selinux' 'selinux=1')
+# SELinux kernel options added to rockstor.kiwi image.preferences.type kernelcmdline= entries.
+if [[ -e /etc/selinux/config ]]; then
+    # SELinux config
+    sed -i -e 's|^SELINUX=.*|SELINUX=permissive|g' \
+           -e 's|^SELINUXTYPE=.*|SELINUXTYPE=targeted|g' \
+           "/etc/selinux/config"
+    echo "-- /etc/selinux/config updated -----"
+    # Grub kernel cmdline additions
+    if [[ -e /etc/default/grub ]]; then
+        sed -i "s|^GRUB_CMDLINE_LINUX_DEFAULT=\"|&${selinuxcmdline[*]} |" /etc/default/grub
+        echo "-- /etc/default/grub updated -------"
+    fi
+    # Sysconfig bootloader cmdline additions (installer boot)
+    if [[ -e /etc/sysconfig/bootloader ]]; then
+        sed -i "s|^DEFAULT_APPEND=\"|&${selinuxcmdline[*]} |" /etc/sysconfig/bootloader
+        sed -i "s|^FAILSAFE_APPEND=\"|&${selinuxcmdline[*]} |" /etc/sysconfig/bootloader
+        echo "-- /etc/sysconfig/bootloader updated"
+    fi
+    # Update kiwi-ng's bootoptions config file used by dracut
+    if [[ -e /config.bootoptions ]]; then
+        sed -i "1 s|.|${selinuxcmdline[*]} &|" /config.bootoptions
+        echo "-- /config.bootoptions updated -----"
+    fi
+fi

--- a/rockstor.kiwi
+++ b/rockstor.kiwi
@@ -46,6 +46,7 @@
         <!-- note: change luks Pass Phrase -->
         <!--        luks="c00l_Pa$$Phra$e" -->
         <!--        luks_version="luks2" -->
+        <!-- N.B. kernelcmdline may be modified by pre_disk_sync.sh -->
         <type image="oem" primary="true" initrd_system="dracut" filesystem="btrfs" fsmountoptions="noatime" firmware="efi" installiso="true" kernelcmdline="nomodeset plymouth.enable=0 rd.kiwi.oem.maxdisk=5000G" bootpartition="false" devicepersistency="by-label" btrfs_root_is_subvolume="true" btrfs_root_is_snapper_snapshot="true" btrfs_quota_groups="false" efipartsize="64">
             <bootloader name="grub2" bls="false"/>
             <!-- For full disk LUKS encryption uncomment below entries -->
@@ -85,6 +86,7 @@
         <bootloader-theme>starfield</bootloader-theme>
         <!-- firmware="efi" See https://github.com/OSInside/kiwi/issues/1428 re AArch64 -->
         <!-- Re AArch64: https://github.com/OSInside/kiwi/issues/1491 -->
+        <!-- N.B. kernelcmdline may be modified by pre_disk_sync.sh -->
         <type image="oem" initrd_system="dracut" filesystem="btrfs" fsmountoptions="noatime,compress=lzo" firmware="efi" kernelcmdline="plymouth.enable=0 rd.kiwi.oem.maxdisk=5000G console=ttyS0,115200 console=tty" bootpartition="false" devicepersistency="by-uuid" btrfs_root_is_subvolume="true" btrfs_root_is_snapper_snapshot="true" btrfs_quota_groups="false" efipartsize="64" editbootinstall="editbootinstall_rpi.sh">
             <bootloader name="grub2" bls="false"/>
             <systemdisk>
@@ -116,6 +118,7 @@
         <bootloader-theme>starfield</bootloader-theme>
         <!-- firmware="efi" See https://github.com/OSInside/kiwi/issues/1428 re AArch64 -->
         <!-- Re AArch64: https://github.com/OSInside/kiwi/issues/1491 -->
+        <!-- N.B. kernelcmdline may be modified by pre_disk_sync.sh -->
         <type image="oem" initrd_system="dracut" filesystem="btrfs" fsmountoptions="noatime,compress=lzo" firmware="efi" kernelcmdline="plymouth.enable=0 rd.kiwi.oem.maxdisk=5000G earlycon" bootpartition="false" devicepersistency="by-uuid" btrfs_root_is_subvolume="true" btrfs_root_is_snapper_snapshot="true" btrfs_quota_groups="false" efipartsize="64" format="qcow2">
             <bootloader name="grub2" bls="false"/>
             <systemdisk>
@@ -333,6 +336,22 @@
         <package name="ntfs-3g"/>
         <!-- ROCKSTOR PACKAGE: CHANGE VERSION AS REQUIRED -->
         <package name="rockstor-5.0.15-0"/>
+    </packages>
+    <!-- SELinux packages -->
+    <!-- See config.sh for kernel & grub configuration -->
+    <!-- Installed pkg count/size with `no-recommends` -->
+    <packages type="image" profiles="Slowroll.x86_64,Tumbleweed.x86_64,Tumbleweed.RaspberryPi4,Tumbleweed.ARM64EFI">
+        <package name="policycoreutils"/>  <!-- 3 pkg 1 MB -->
+        <package name="setools-console"/>  <!-- 3 pkg 15 MB -->
+        <package name="restorecond"/>  <!-- 1 pkg 24 KB -->
+        <package name="audit"/>  <!-- 4 pkg 777 KB -->
+        <package name="selinux-policy"/>   <!-- default permissive/targeted -->
+        <package name="selinux-policy-targeted"/>   <!-- targeted base module depends on selinux-policy -->
+        <package name="checkpolicy"/>  <!-- 1 pkg 2 MB -->
+        <package name="python311-semanage"/>  <!-- 1 pkg 378 KB requried for semanage -->
+        <package name="python311-selinux"/>  <!-- 1 pkg 550 KB requried for semanage -->
+        <package name="policycoreutils-python-utils"/>  <!-- 59 pkg 70.4 MB - semanage plus bloat -->
+        <package name="selinux-autorelabel"/>  <!-- 1 pkg 28 KB early boot relabelling -->
     </packages>
     <packages type="image" profiles="Leap15.6.RaspberryPi4,Tumbleweed.RaspberryPi4">
         <package name="raspberrypi-eeprom" arch="aarch64"/>


### PR DESCRIPTION
"SELinux packages" section for Slowroll & Tumbleweed profiles. SELinux kernel options added to existing rockstor.kiwi options via pre_disk_sync.sh if `/etc/selinux/config` is found.

A permissive and targeted config is established; corresponding to current package defaults.

Incidental Zypper config changes:
- Disable doc installation by default.
- Default to --no-recommends.

Fixes #200 

---

Squashed variant of the last version of draft PR #203 

Caveat RPC pip service fails 'stop' on shutdown after having added: selinux-autorelabel. This does not however affect the shutdown itself.