### PR TITLE
Disable dmraid (ATA)RAID Intel BIOS-RAID related service #204

### DIFF
--- a/rockstor.kiwi
+++ b/rockstor.kiwi
@@ -275,7 +275,6 @@
         <package name="cifs-utils"/>
         <package name="cryptsetup"/>
         <package name="dhcp-client"/>
-        <package name="dmraid"/>
         <package name="dosfstools"/> <!-- For fscking /boot/efi -->
         <package name="dracut"/>
         <package name="dracut-kiwi-oem-dump"/>


### PR DESCRIPTION
Remove dmraid package from list of default packages. This is not a dependency of Rockstor and is now rarely relevant.

Fixes #204 