### PR TITLE
Installer to latest RC and introduce RPi5 profile (#213)

### DIFF
--- a/README.md
+++ b/README.md
@@ -223,6 +223,22 @@ Executed, as the root user, in the directory containing this repository's `rocks
 ```shell
 kiwi-ng --profile=Leap16.0.RaspberryPi4 --type oem system build --description ./ --target-dir /home/kiwi-images/
 ```
+### Tumbleweed.RaspberryPi5 profile
+Executed, as the root user, in the directory containing this repository's `rockstor.kiwi` file.
+
+```shell
+kiwi-ng --profile=Tumbleweed.RaspberryPi5 --type oem system build --description ./ --target-dir /home/kiwi-images/
+```
+Since the rpi5 comes with a changed architecture and a new chip (BCM2712), it took quite some time to make it work for OpenSUSE.
+Finally, at the end of 2025 openSUSE has started offering the first (Tumbleweed only) rpi5 images that can be written directly to the SD card using `rip imager` and boot them up.
+The (wiki page)[https://en.opensuse.org/HCL:Raspberry_Pi5] is periodically updated with remaining issues and other news related to this porting effort.
+In order to create a Rockstor Pi5 installer, it requires `kiwi-ng` to be run on actual pi5 hardware.
+(So far, qemu/KVM based builds have been unsuccessful due to the boot section being markedly different from typical aarch64 builds).
+After installing the OpenSUSE base image, and the above mentioned preparations (install packages on build host), a Rockstor `raw` image can be successfully built.
+That image can then be written to the SD card using the graphical `rpi-imager` software (windows or linux).
+
+Note: As of May 2026 there is no option to use Rockstor on the jeOS base image using the rpm installation method via zypper. The installation is successful,
+but because the base images uses `ext4` as its file system and not btrfs, Rockstor will not allow for the setup to proceed.
 
 ## Resulting Rockstor installers
 With the above suggested `kiwi-ng` commands the resulting installers will be found in **/home/kiwi-images/** on the kiwi-ng host systems.

--- a/README.md
+++ b/README.md
@@ -11,24 +11,27 @@ Please test your modifications on all affected profiles prior to submission and 
 Profiles are named after their upstream distribution base, i.e. openSUSE Leap version,
 and then the intended target system; with the two elements separated by a ".".
 
-The "target system" element is either generic, i.e. **x86_64** or **AArch64**, or target system specific, i.e. **RaspberryPi4** or **ARM64EFI**.
+The "target system" element is either generic, i.e. **x86_64** or **AArch64**, or target system specific, i.e. **RaspberryPi4/5**, or **ARM64EFI**.
 With the latter ARM64EFI spanning both generic (Arm64) and specific (64 bit EFI).
 
 ## Core Profiles
 Our current pre-built installers are built using the following profiles (see: [Downloads](https://rockstor.com/dls.html)):
 
-- **Leap15.6.x86_64**
-- **Leap15.6.RaspberryPi4**
-- **Leap15.6.ARM64EFI**
+- **Leap16.0.x86_64**
+- **Leap16.0.RaspberryPi4**
+- **Leap16.0.ARM64EFI**
 - **Slowroll.x86_64**
 - **Tumbleweed.x86_64**
 - **Tumbleweed.RaspberryPi4**
 - **Tumbleweed.ARM64EFI**
 
-### Pi4 USB boot
-USB booting on the Pi4 may require a bootloader update via a fully updated Raspberry OS.
-Pi4 EEPROM/bootloader version "Jun 15 2020" or later will be required for USB boot,
-regardless of any installer/EFI file changes.
+Experimental Profile:
+- **Tumbleweed.RaspberryPi5**
+
+### RaspberryPi USB boot
+USB booting on the Pi 4 may require a bootloader update via a fully updated Raspberry OS.
+Pi4 EEPROM/bootloader version "Jun 15 2020" or later will be required for USB boot, regardless of any installer/EFI file changes.
+For the Pi 5 apply the latest bootloader available, as this is still in active development.
 
 ### Special mention
 - ARM64EFI
@@ -53,8 +56,8 @@ and the [howto subsection](#howto) below to test proposed changes.
 
 Please see the [kiwi-ng docs overview](https://osinside.github.io/kiwi/overview.html) for the canonical
 [System Requirements](https://osinside.github.io/kiwi/overview.html#system-requirements) for building the installer:
-e.g., 15 GB free space, Python version, etc.
-It is recommended to use at least Kiwi-ng v10.2.13 to build our [Core Profiles](#core-profiles).
+e.g. 15 GB free space, Python version, etc.
+It is recommended to use at least kiwi-ng v10.3.0 to build our [Core Profiles](#core-profiles).
 
 Given our profiles' target OSs are exclusively 'Built on openSUSE',
 a vanilla openSUSE Leap 15.6 instance is recommended if not using the kiwi-ng boxbuild method.
@@ -147,20 +150,13 @@ For an openSUSE Leap 15.6 OS from kiwi-ng's doc [Installation](https://osinside.
 Any x86_64 machine, keeping in mind that building an installer is computationally expensive,
 so systems with a decent-sized CPU/RAM combination released in the last 5-7 years is recommended.
 
-##### Leap 15.6 host
-The openSUSE host version should ideally be at least the version of the target profile.
-Since Leap 15.6 ships with a default `python 3.6x` it is necessary to install a higher python version (e.g., `3.11`):
+##### Host with Leap 16.x or Tumbleweed
+As the newer distributions already have the required python3 versions,
+just add the the required repository as per distribution (for Slowroll use `openSUSE_Tumbleweed` as well):
 
+e.g. for 16.0:
 ```shell
-sudo zypper in python311
-```
-
-then add the required repository:
-
-for 15.6
-
-```shell
-sudo zypper addrepo https://download.opensuse.org/repositories/Virtualization:/Appliances:/Builder/openSUSE_Leap_15.6/ appliance-builder
+sudo zypper addrepo https://download.opensuse.org/repositories/Virtualization:/Appliances:/Builder/openSUSE_LEAP_16.0/ appliance-builder
 ```
 
 and install kiwi and the additional requirements as shown below:
@@ -169,11 +165,29 @@ and install kiwi and the additional requirements as shown below:
 sudo zypper install python3-kiwi btrfsprogs gfxboot qemu-tools gptfdisk e2fsprogs squashfs xorriso dosfstools
 ```
 
-#### AArch64 host (e.g., a Pi4) for AArch64 profiles
+##### Host with Leap < 16.0
+The openSUSE host version should ideally be at least the version of the target profile.
+Since older Leap versions (EOL) can ship with a default python version that is less than the minimum requirement of `python 3.9`,
+it is necessary to install a higher python version (e.g., `3.13`):
+
+```shell
+sudo zypper in python313
+```
+
+then add the required repository, e.g.
+
+for 15.6
+
+```shell
+sudo zypper addrepo https://download.opensuse.org/repositories/Virtualization:/Appliances:/Builder/openSUSE_Leap_15.6/ appliance-builder
+```
+
+Then proceed to install kiwi and the additional requirements as above.
+
+#### AArch64 host (e.g. a Pi4) for AArch64 profiles
 See [HCL:Raspberry Pi4](https://en.opensuse.org/HCL:Raspberry_Pi4).
-Install, for example, an appliance JeOS Leap 15.6 image as the host OS.
-Enabling USB boot on older Pi4 systems will allow for the use of, for example,
-an SSD as the system drive which will massively speed up installer building.
+Install, for example, an appliance JeOS Leap 16.0 image as the host OS.
+Enabling USB boot on older Pi4 systems will allow for the use of, for example, an SSD as the system drive which will massively speed up installer building.
 See [Pi4 USB boot](#pi4-usb-boot).
 
 ### Edit rockstor.kiwi
@@ -181,7 +195,7 @@ No edit is required if you wish to use the generic installer filename and defaul
 To change these defaults edit all lines directly preceded by **<!--Change to ...** as per the **...** details given.
 Our release infrastructure performs these same edits to set official installer filenames and rockstor package versions.
 
-#### Stable Kernel Backport & matching btrfs-progs
+#### Stable Kernel Backport & matching btrfs-progs (only applicable for OpenSUSE LEAP < 16.0)
 To enable the use of 'Stable Kernel Backport' and 'filesystems' repositories within our `rockstor.kiwi` config,
 uncomment the corresponding repositories.
 For more information about using the most recent kernels see
@@ -189,25 +203,25 @@ For more information about using the most recent kernels see
 
 #### Root disk LUKS encryption
 If you want to enable LUKS encryption of the Root disk (where Rockstor is installed),
-uncomment the relevant parameters available as example in the **Leap15.6.x86_64** profile.
+uncomment the relevant parameters available as example in the **Leap16.0.x86_64** profile.
 This will enable `LUKS2` encryption and utilize PBKDF2, as grub does not yet support the more recent `argon2id` algorithm.
 
 N.B.: The `luksformat` parameter's preceding hyphens have to be escaped to exist as a comment.
 When adding more non-commented parameters,
 the required double-hyphens can be inserted without escaping them to their Unicode character codes.
 
-### Leap15.6.x86_64 profile
+### Leap16.0.x86_64 profile
 Executed, as the root user, in the directory containing this repository's `rockstor.kiwi` file.
 
 ```shell
-kiwi-ng --profile=Leap15.6.x86_64 --type oem system build --description ./ --target-dir /home/kiwi-images/
+kiwi-ng --profile=Leap16.0.x86_64 --type oem system build --description ./ --target-dir /home/kiwi-images/
 ```
 
-### Leap15.6.RaspberryPi4 profile
+### Leap16.0.RaspberryPi4 profile
 Executed, as the root user, in the directory containing this repository's `rockstor.kiwi` file.
 
 ```shell
-kiwi-ng --profile=Leap15.6.RaspberryPi4 --type oem system build --description ./ --target-dir /home/kiwi-images/
+kiwi-ng --profile=Leap16.0.RaspberryPi4 --type oem system build --description ./ --target-dir /home/kiwi-images/
 ```
 
 ## Resulting Rockstor installers
@@ -215,7 +229,7 @@ With the above suggested `kiwi-ng` commands the resulting installers will be fou
 
 - For the x86_64 profiles the resulting installer is an ISO image intended for image transfer to an installer only device.
 Use the file ending in ".iso".
-- For the RaspberryPi4 profile the resulting installer is an uncompressed raw disk image intended for image transfer to the target system disk directly.
+- For the RaspberryPi 4 and 5 profiles the resulting installer is an uncompressed raw disk image intended for image transfer to the target system disk directly.
 Use the file ending in ".raw".
 
 The resulting installs will grow on first boot to the size of their host devices.
@@ -226,13 +240,11 @@ Please see [Rockstor’s “Built on openSUSE” installer](https://rockstor.com
 ## Help or Assistance
 Our [friendly forum](https://forum.rockstor.com/) is a good place to ask question regarding this How-to.
 If you enable any of the above described enhancements i.e. backported kernel, LUKS, or add other options,
-be sure to include their details when reporting any problems.
-Please be patient as our support is community based and the above procedures are always in-flux/development.
+be sure to include those details when reporting any problems.
+Please be patient as our support is community based and the above procedures are always in flux/development.
 
-If you find an issues with these instructions, or the kiwi-ng config,
-please consider creating an issue and submitting a pull request with a proposed fix.
+If you find an issue with these instructions, or the kiwi-ng config, please consider creating an issue and submitting a pull request with a proposed fix.
 
-[The Rockstor Project](https://opencollective.com/the-rockstor-project) is an [Open Collective](https://opencollective.com/)
-Non-Profit/Non-Business Open Source community endeavour.
-As such it depends on subscriptions and contributions for its sustainability.
-
+[The Rockstor Project](https://opencollective.com/the-rockstor-project) is an [Open Collective](https://opencollective.com/) Non-Profit/Non-Business Open Source community endeavour.
+We are supported by our contributors, and fiscally hosted by [Open Source Europe (OSE)](https://opencollective.com/europe).
+As such it depends on contributions for its sustainability.

--- a/README.md
+++ b/README.md
@@ -162,7 +162,7 @@ sudo zypper addrepo https://download.opensuse.org/repositories/Virtualization:/A
 and install kiwi and the additional requirements as shown below:
 
 ```shell
-sudo zypper install python3-kiwi btrfsprogs gfxboot qemu-tools gptfdisk e2fsprogs squashfs xorriso dosfstools
+sudo zypper install python3-kiwi btrfsprogs qemu-tools gptfdisk e2fsprogs squashfs xorriso dosfstools binutils
 ```
 
 ##### Host with Leap < 16.0

--- a/rockstor.kiwi
+++ b/rockstor.kiwi
@@ -77,7 +77,7 @@
         </type>
     </preferences>
     <preferences profiles="Leap16.0.RaspberryPi4,Tumbleweed.RaspberryPi4,Tumbleweed.RaspberryPi5">
-        <version>5.0.15-0</version>
+        <version>5.5.3-0</version>
         <packagemanager>zypper</packagemanager>
         <locale>en_GB</locale>
         <keytable>gb</keytable>
@@ -109,7 +109,7 @@
         </type>
     </preferences>
     <preferences profiles="Leap16.0.ARM64EFI,Tumbleweed.ARM64EFI">
-        <version>5.0.15-0</version>
+        <version>5.5.3-0</version>
         <packagemanager>zypper</packagemanager>
         <locale>en_GB</locale>
         <keytable>gb</keytable>
@@ -317,7 +317,7 @@
         <package name="syslinux" arch="x86_64"/>
         <package name="systemd"/>
         <package name="systemd-presets-branding"/> <!-- or branding-openSUSE -->
-        <package name="systemd-sysvinit"/>
+        <!-- <package name="systemd-sysvinit"/> -->
         <package name="tar"/>
         <package name="timezone"/>
         <package name="tree"/>

--- a/rockstor.kiwi
+++ b/rockstor.kiwi
@@ -6,8 +6,9 @@
 <!-- https://en.opensuse.org/Portal:JeOS -->
 <!-- https://documentation.suse.com/kiwi/9/single-html/kiwi/index.html -->
 <!-- https://build.opensuse.org/package/show/openSUSE:Leap:15.6/kiwi-templates-Minimal -->
-<!-- https://build.opensuse.org/package/show/openSUSE:Leap:15.6:Images/kiwi-templates-Minimal -->
-<!-- https://build.opensuse.org/package/show/openSUSE:Leap:15.6:Images/JeOS -->
+<!-- https://build.opensuse.org/package/show/openSUSE:Leap:16.0:Images/JeOS -->
+<!-- Package sources for project openSUSE:Leap:16.0 onwards are now managed through scm. -->
+<!-- https://src.opensuse.org/openSUSE/Leap-Images#leap-16.0 -->
 <!-- OBS-Profiles: @BUILD_FLAVOR@ -->
 <image schemaversion="8.3" name="Rockstor-NAS">
     <description type="system">
@@ -21,16 +22,17 @@
         <!-- For preferences, drivers, repository, packages, and users elements -->
         <!-- https://osinside.github.io/kiwi/working_with_images/build_with_profiles.html -->
         <!-- N.B. can inherit one profile within another via requires profile="" -->
-        <profile name="Leap15.6.x86_64" description="Rockstor built on openSUSE Leap 15.6 x86_64" arch="x86_64"/>
-        <profile name="Leap15.6.RaspberryPi4" description="Rockstor built on openSUSE Leap 15.6 Raspberry_Pi" arch="aarch64"/>
-        <profile name="Leap15.6.ARM64EFI" description="Rockstor built on openSUSE Leap 15.6 ARM64 EFI/VM/Ten64" arch="aarch64"/>
+        <profile name="Leap16.0.x86_64" description="Rockstor built on openSUSE Leap 16.0 x86_64" arch="x86_64"/>
+        <profile name="Leap16.0.RaspberryPi4" description="Rockstor built on openSUSE Leap 16.0 Raspberry_Pi" arch="aarch64"/>
+        <profile name="Leap16.0.ARM64EFI" description="Rockstor built on openSUSE Leap 16.0 ARM64 EFI/VM/Ten64" arch="aarch64"/>
         <profile name="Slowroll.x86_64" description="Rockstor built on openSUSE Slowroll x86_64" arch="x86_64"/>
         <profile name="Tumbleweed.x86_64" description="Rockstor built on openSUSE Tumbleweed x86_64" arch="x86_64"/>
         <profile name="Tumbleweed.RaspberryPi4" description="Rockstor built on openSUSE Tumbleweed Raspberry_Pi" arch="aarch64"/>
+        <profile name="Tumbleweed.RaspberryPi5" description="Rockstor built on openSUSE Tumbleweed Raspberry_Pi5" arch="aarch64"/>
         <profile name="Tumbleweed.ARM64EFI" description="Rockstor built on openSUSE Tumbleweed ARM64 EFI/VM/Ten64" arch="aarch64"/>
     </profiles>
-    <preferences profiles="Leap15.6.x86_64,Slowroll.x86_64,Tumbleweed.x86_64">
-        <version>5.0.15-0</version>
+    <preferences profiles="Leap16.0.x86_64,Slowroll.x86_64,Tumbleweed.x86_64">
+        <version>5.5.3-0</version>
         <packagemanager>zypper</packagemanager>
         <locale>en_GB</locale>
         <keytable>gb</keytable>
@@ -74,7 +76,7 @@
             </oemconfig>
         </type>
     </preferences>
-    <preferences profiles="Leap15.6.RaspberryPi4,Tumbleweed.RaspberryPi4">
+    <preferences profiles="Leap16.0.RaspberryPi4,Tumbleweed.RaspberryPi4,Tumbleweed.RaspberryPi5">
         <version>5.0.15-0</version>
         <packagemanager>zypper</packagemanager>
         <locale>en_GB</locale>
@@ -106,7 +108,7 @@
             </oemconfig>
         </type>
     </preferences>
-    <preferences profiles="Leap15.6.ARM64EFI,Tumbleweed.ARM64EFI">
+    <preferences profiles="Leap16.0.ARM64EFI,Tumbleweed.ARM64EFI">
         <version>5.0.15-0</version>
         <packagemanager>zypper</packagemanager>
         <locale>en_GB</locale>
@@ -144,58 +146,47 @@
     </users>
     <!-- https://en.opensuse.org/Package_repositories -->
     <!-- Alias repo-oss Name="Main Repository" in JeOS -->
-    <repository type="rpm-md" alias="Leap_15_6" imageinclude="true" profiles="Leap15.6.x86_64,Leap15.6.RaspberryPi4,Leap15.6.ARM64EFI">
-        <source path="obs://openSUSE:Leap:15.6/standard"/>
+    <repository type="rpm-md" alias="repo-oss" imageinclude="true" profiles="Leap16.0.x86_64,Leap16.0.RaspberryPi4,Leap16.0.ARM64EFI">
+        <source path="https://cdn.opensuse.org/distribution/leap/16.0/repo/oss/"/>
     </repository>
     <repository type="rpm-md" alias="repo-oss" imageinclude="true" profiles="Slowroll.x86_64">
-        <source path="https://download.opensuse.org/slowroll/repo/oss"/>
+        <source path="https://cdn.opensuse.org/slowroll/repo/oss"/>
     </repository>
-    <repository type="rpm-md" alias="Tumbleweed" imageinclude="true" profiles="Tumbleweed.x86_64">
-        <source path="obs://openSUSE:Tumbleweed/standard"/>
+    <repository type="rpm-md" alias="repo-oss" imageinclude="true" profiles="Tumbleweed.x86_64">
+        <source path="https://cdn.opensuse.org/tumbleweed/repo/oss/"/>
     </repository>
-    <repository type="rpm-md" alias="Tumbleweed" imageinclude="true" profiles="Tumbleweed.RaspberryPi4,Tumbleweed.ARM64EFI">
-        <source path="https://download.opensuse.org/ports/aarch64/tumbleweed/repo/oss/"/>
+    <repository type="rpm-md" alias="repo-oss" imageinclude="true" profiles="Tumbleweed.RaspberryPi4,Tumbleweed.RaspberryPi5,Tumbleweed.ARM64EFI">
+        <source path="https://cdn.opensuse.org/ports/aarch64/tumbleweed/repo/oss/"/>
     </repository>
     <!-- Alias repo-update Name="Main Update Repository" or "openSUSE-Tumbleweed-Update" in JeOS -->
-    <repository type="rpm-md" alias="Leap_15_6_Updates" imageinclude="true" profiles="Leap15.6.x86_64,Leap15.6.RaspberryPi4,Leap15.6.ARM64EFI">
-        <source path="https://download.opensuse.org/update/leap/15.6/oss/"/>
+    <repository type="rpm-md" alias="repo-update" imageinclude="true" profiles="Leap16.0.x86_64,Leap16.0.RaspberryPi4,Leap16.0.ARM64EFI">
+        <source path="https://cdn.opensuse.org/distribution/leap/16.0/repo/oss/"/>
     </repository>
-    <repository type="rpm-md" alias="update-slowroll" imageinclude="true" profiles="Slowroll.x86_64">
-        <source path="https://download.opensuse.org/update/slowroll/repo/oss"/>
+    <repository type="rpm-md" alias="openSUSE-Slowroll-Update" imageinclude="true" profiles="Slowroll.x86_64">
+        <source path="https://download.opensuse.org/update/slowroll/repo/oss/"/>
     </repository>
-    <repository type="rpm-md" alias="Tumbleweed_Updates" imageinclude="true" profiles="Tumbleweed.x86_64">
+    <repository type="rpm-md" alias="openSUSE-Tumbleweed-Update" imageinclude="true" profiles="Tumbleweed.x86_64">
         <source path="https://download.opensuse.org/update/tumbleweed/"/>
     </repository>
-    <!-- Alias repo-backports-update Name="Update repository of openSUSE Backports" -->
-    <!-- or "openSUSE_Backports_SLE-15-SP3_Update" / "Online updates for openSUSE:Backports:SLE-15-SP3 (standard)" -->
-    <!-- Alias repo-sle-update Name="Update repository with updates from SUSE Linux Enterprise 15" -->
-    <!-- or "openSUSE_Leap_15.3_SLE-Update" / "Online updates for openSUSE Leap 15.3 (SLE)" -->
-    <!-- See: https://doc.opensuse.org/release-notes/x86_64/openSUSE/Leap/15.3/#installation-new-update-repos -->
-    <!-- Leap 15.3+ profiles only - repos are multi architecture -->
-    <!-- Not included in image as auto added by installed system. -->
-    <!-- Used during image build to capture updates at time of installer build -->
-    <repository type="rpm-md" alias="repo-backports-update" profiles="Leap15.6.x86_64,Leap15.6.RaspberryPi4,Leap15.6.ARM64EFI">
-        <source path="https://download.opensuse.org/update/leap/15.6/backports/"/>
-    </repository>
-    <repository type="rpm-md" alias="repo-sle-update" profiles="Leap15.6.x86_64,Leap15.6.RaspberryPi4,Leap15.6.ARM64EFI">
-        <source path="https://download.opensuse.org/update/leap/15.6/sle/"/>
+    <repository type="rpm-md" alias="repo-update" imageinclude="true" profiles="Tumbleweed.RaspberryPi4,Tumbleweed.RaspberryPi5,Tumbleweed.ARM64EFI">
+        <source path="https://download.opensuse.org/ports/aarch64/update/tumbleweed/"/>
     </repository>
     <!-- open H264 repos: -->
     <!-- https://news.opensuse.org/2023/01/24/opensuse-simplifies-codec-install/ -->
     <!-- https://codecs.opensuse.org/openh264/ -->
-    <repository type="rpm-md" alias="repo-openh264" imageinclude="true" profiles="Leap15.6.x86_64,Leap15.6.RaspberryPi4,Leap15.6.ARM64EFI">
-        <source path="http://codecs.opensuse.org/openh264/openSUSE_Leap"/>
+    <repository type="rpm-md" alias="repo-openh264" imageinclude="true" profiles="Leap16.0.x86_64,Leap16.0.RaspberryPi4,Leap16.0.ARM64EFI">
+        <source path="http://codecs.opensuse.org/openh264/openSUSE_Leap_16"/>
     </repository>
-    <repository type="rpm-md" alias="repo-openh264" imageinclude="true" profiles="Slowroll.x86_64,Tumbleweed.x86_64,Tumbleweed.RaspberryPi4,Tumbleweed.ARM64EFI">
+    <repository type="rpm-md" alias="repo-openh264" imageinclude="true" profiles="Slowroll.x86_64,Tumbleweed.x86_64,Tumbleweed.RaspberryPi4,Tumbleweed.RaspberryPi5,Tumbleweed.ARM64EFI">
         <source path="http://codecs.opensuse.org/openh264/openSUSE_Tumbleweed"/>
     </repository>
     <!-- Virtualization_Appliances_Builder repos: -->
     <!-- Latest Kiwi-ng & Dracut helpers:  -->
     <!-- https://build.opensuse.org/project/show/Virtualization:Appliances:Builder -->
-    <repository type="rpm-md" alias="Virtualization_Appliances_Builder" imageinclude="true" profiles="Leap15.6.x86_64,Leap15.6.RaspberryPi4,Leap15.6.ARM64EFI">
-        <source path="https://download.opensuse.org/repositories/Virtualization:/Appliances:/Builder/openSUSE_Leap_15.6/"/>
+    <repository type="rpm-md" alias="Virtualization_Appliances_Builder" imageinclude="true" profiles="Leap16.0.x86_64,Leap16.0.RaspberryPi4,Leap16.0.ARM64EFI">
+        <source path="https://download.opensuse.org/repositories/Virtualization:/Appliances:/Builder/openSUSE_Leap_16.0/"/>
     </repository>
-    <repository type="rpm-md" alias="Virtualization_Appliances_Builder" imageinclude="true" profiles="Slowroll.x86_64,Tumbleweed.x86_64,Tumbleweed.RaspberryPi4,Tumbleweed.ARM64EFI">
+    <repository type="rpm-md" alias="Virtualization_Appliances_Builder" imageinclude="true" profiles="Slowroll.x86_64,Tumbleweed.x86_64,Tumbleweed.RaspberryPi4,Tumbleweed.RaspberryPi5,Tumbleweed.ARM64EFI">
         <source path="https://download.opensuse.org/repositories/Virtualization:/Appliances:/Builder/openSUSE_Tumbleweed/"/>
     </repository>
     <!-- https://osinside.github.io/kiwi/concept_and_workflow/repository_setup.html -->
@@ -205,10 +196,10 @@
     <!--    </repository> -->
     <!-- Resource Rockstor Testing channel during installer build only -->
     <!-- Rockstor repos are multi-arch from 15.4 onwards -->
-    <repository type="rpm-md" alias="Rockstor-Testing" profiles="Leap15.6.x86_64,Leap15.6.RaspberryPi4,Leap15.6.ARM64EFI">
-        <source path="http://updates.rockstor.com:8999/rockstor-testing/leap/15.6/"/>
+    <repository type="rpm-md" alias="Rockstor-Testing" profiles="Leap16.0.x86_64,Leap16.0.RaspberryPi4,Leap16.0.ARM64EFI">
+        <source path="http://updates.rockstor.com:8999/rockstor-testing/leap/16.0/"/>
     </repository>
-    <repository type="rpm-md" alias="Rockstor-Testing" profiles="Slowroll.x86_64,Tumbleweed.x86_64,Tumbleweed.RaspberryPi4,Tumbleweed.ARM64EFI">
+    <repository type="rpm-md" alias="Rockstor-Testing" profiles="Slowroll.x86_64,Tumbleweed.x86_64,Tumbleweed.RaspberryPi4,Tumbleweed.RaspberryPi5,Tumbleweed.ARM64EFI">
         <source path="http://updates.rockstor.com:8999/rockstor-testing/tumbleweed/"/>
     </repository>
     <!-- For shellinabox package -->
@@ -218,26 +209,27 @@
     <!-- Rockstor home repo on OBS for Leap 15.3 + now hosts dual arch shellinabox -->
     <!-- Maintain lower priority to upstream in case shellinabox is added there -->
     <!-- https://build.opensuse.org/project/show/home:rockstor -->
-    <repository type="rpm-md" alias="home_rockstor" priority="105" imageinclude="true" profiles="Leap15.6.x86_64,Leap15.6.RaspberryPi4,Leap15.6.ARM64EFI">
+    <!-- As of 05/20/2026 shellinabox package is not available for Leap 16.0, so continue to use 15.6 for now. -->
+    <repository type="rpm-md" alias="home_rockstor" priority="105" imageinclude="true" profiles="Leap16.0.x86_64,Leap16.0.RaspberryPi4,Leap16.0.ARM64EFI">
         <source path="https://download.opensuse.org/repositories/home:/rockstor/15.6/"/>
     </repository>
     <repository type="rpm-md" alias="home_rockstor" priority="105" imageinclude="true" profiles="Slowroll.x86_64">
         <source path="https://download.opensuse.org/repositories/home:/rockstor/openSUSE_Slowroll/"/>
     </repository>
-    <repository type="rpm-md" alias="home_rockstor" priority="105" imageinclude="true" profiles="Tumbleweed.x86_64,Tumbleweed.RaspberryPi4,Tumbleweed.ARM64EFI">
+    <repository type="rpm-md" alias="home_rockstor" priority="105" imageinclude="true" profiles="Tumbleweed.x86_64,Tumbleweed.RaspberryPi4,Tumbleweed.RaspberryPi5,Tumbleweed.ARM64EFI">
         <source path="https://download.opensuse.org/repositories/home:/rockstor/openSUSE_Tumbleweed/"/>
     </repository>
     <!-- This repo currently provides: systemd-presets-branding-rockstor -->
     <!-- As per https://en.opensuse.org/Archive:Making_an_openSUSE_based_distribution -->
     <!-- We are required to de/re-brand packages that have no "...branding-upstream" equivalent -->
     <!-- https://build.opensuse.org/package/show/home:rockstor:branches:Base:System/systemd-presets-branding-rockstor -->
-    <repository type="rpm-md" alias="home_rockstor_branches_Base_System" priority="97" imageinclude="true" profiles="Leap15.6.x86_64,Leap15.6.RaspberryPi4,Leap15.6.ARM64EFI">
-        <source path="https://download.opensuse.org/repositories/home:/rockstor:/branches:/Base:/System/15.6/"/>
+    <repository type="rpm-md" alias="home_rockstor_branches_Base_System" priority="97" imageinclude="true" profiles="Leap16.0.x86_64,Leap16.0.RaspberryPi4,Leap16.0.ARM64EFI">
+        <source path="https://download.opensuse.org/repositories/home:/rockstor:/branches:/Base:/System/16.0/"/>
     </repository>
     <repository type="rpm-md" alias="home_rockstor_branches_Base_System" priority="97" imageinclude="true" profiles="Slowroll.x86_64">
         <source path="https://download.opensuse.org/repositories/home:/rockstor:/branches:/Base:/System/openSUSE_Slowroll/"/>
     </repository>
-    <repository type="rpm-md" alias="home_rockstor_branches_Base_System" priority="97" imageinclude="true" profiles="Tumbleweed.x86_64,Tumbleweed.RaspberryPi4,Tumbleweed.ARM64EFI">
+    <repository type="rpm-md" alias="home_rockstor_branches_Base_System" priority="97" imageinclude="true" profiles="Tumbleweed.x86_64,Tumbleweed.RaspberryPi4,Tumbleweed.RaspberryPi5,Tumbleweed.ARM64EFI">
         <source path="https://download.opensuse.org/repositories/home:/rockstor:/branches:/Base:/System/openSUSE_Tumbleweed/"/>
     </repository>
     <!-- THE FOLLOWING KERNEL REPOS ARE NOT SUPPORTED. -->
@@ -249,21 +241,21 @@
     <!-- Kernel HEAD Backports -->
     <!-- https://build.opensuse.org/repositories/Kernel:HEAD:Backport -->
     <!--    <repository type="rpm-md" alias="Kernel_HEAD_Backport" imageinclude="true" -->
-    <!--                profiles="Leap15.6.x86_64,Leap15.6.RaspberryPi4,Leap15.6.ARM64EFI"> -->
+    <!--                profiles="Leap16.0.x86_64,Leap16.0.RaspberryPi4,Leap16.0.ARM64EFI"> -->
     <!--        <source path="https://download.opensuse.org/repositories/Kernel:/HEAD:/Backport/standard/"/> -->
     <!--    </repository> -->
     <!-- Kernel Stable Backports -->
     <!-- https://build.opensuse.org/project/show/Kernel:stable:Backport -->
     <!-- See also: https://rockstor.com/docs/howtos/stable_kernel_backport.html  -->
     <!--    <repository type="rpm-md" alias="Kernel_stable_Backport" imageinclude="true" -->
-    <!--                profiles="Leap15.6.x86_64,Leap15.6.RaspberryPi4,Leap15.6.ARM64EFI"> -->
+    <!--                profiles="Leap16.0.x86_64,Leap16.0.RaspberryPi4,Leap16.0.ARM64EFI"> -->
     <!--        <source path="https://download.opensuse.org/repositories/Kernel:/stable:/Backport/standard/"/> -->
     <!--    </repository>-->
     <!-- btrfs-progs backport via filesystems repo -->
     <!-- https://build.opensuse.org/project/show/filesystems -->
     <!--    <repository type="rpm-md" alias="filesystems" imageinclude="true" -->
-    <!--                profiles="Leap15.6.x86_64,Leap15.6.RaspberryPi4,Leap15.6.ARM64EFI"> -->
-    <!--        <source path="https://download.opensuse.org/repositories/filesystems/15.6/"/> -->
+    <!--                profiles="Leap16.0.x86_64,Leap16.0.RaspberryPi4,Leap16.0.ARM64EFI"> -->
+    <!--        <source path="https://download.opensuse.org/repositories/filesystems/16.0/"/> -->
     <!--    </repository> -->
     <packages type="image">
         <package name="adaptec-firmware"/> <!-- Razor AIC94xx Series SAS -->
@@ -334,12 +326,12 @@
         <package name="which"/>
         <package name="ntfs-3g"/>
         <!-- ROCKSTOR PACKAGE: CHANGE VERSION AS REQUIRED -->
-        <package name="rockstor-5.0.15-0"/>
+        <package name="rockstor-5.5.3-0"/>
     </packages>
     <!-- SELinux packages -->
     <!-- See config.sh for kernel & grub configuration -->
     <!-- Installed pkg count/size with `no-recommends` -->
-    <packages type="image" profiles="Slowroll.x86_64,Tumbleweed.x86_64,Tumbleweed.RaspberryPi4,Tumbleweed.ARM64EFI">
+    <packages type="image" profiles="Slowroll.x86_64,Tumbleweed.x86_64,Tumbleweed.RaspberryPi4,Tumbleweed.RaspberryPi5,Tumbleweed.ARM64EFI">
         <package name="policycoreutils"/>  <!-- 3 pkg 1 MB -->
         <package name="setools-console"/>  <!-- 3 pkg 15 MB -->
         <package name="restorecond"/>  <!-- 1 pkg 24 KB -->
@@ -347,19 +339,25 @@
         <package name="selinux-policy"/>   <!-- default permissive/targeted -->
         <package name="selinux-policy-targeted"/>   <!-- targeted base module depends on selinux-policy -->
         <package name="checkpolicy"/>  <!-- 1 pkg 2 MB -->
-        <package name="python311-semanage"/>  <!-- 1 pkg 378 KB requried for semanage -->
-        <package name="python311-selinux"/>  <!-- 1 pkg 550 KB requried for semanage -->
+        <package name="python313-semanage"/>  <!-- 1 pkg 378 KB requried for semanage -->
+        <package name="python313-selinux"/>  <!-- 1 pkg 550 KB requried for semanage -->
         <package name="policycoreutils-python-utils"/>  <!-- 59 pkg 70.4 MB - semanage plus bloat -->
         <package name="selinux-autorelabel"/>  <!-- 1 pkg 28 KB early boot relabelling -->
     </packages>
-    <packages type="image" profiles="Leap15.6.RaspberryPi4,Tumbleweed.RaspberryPi4">
+    <packages type="image" profiles="Leap16.0.RaspberryPi4,Tumbleweed.RaspberryPi4,Tumbleweed.RaspberryPi5">
         <package name="raspberrypi-eeprom" arch="aarch64"/>
         <package name="raspberrypi-firmware" arch="aarch64"/>
         <package name="raspberrypi-firmware-config" arch="aarch64"/>
         <package name="raspberrypi-firmware-dt" arch="aarch64"/>
+        <package name="u-boot-rpiarm64" arch="aarch64"/>
+    </packages>
+    <packages type="image" profiles="Leap16.0.RaspberryPi4,Tumbleweed.RaspberryPi4">
         <!-- For WiFi: -->
         <package name="bcm43xx-firmware"/>
-        <package name="u-boot-rpiarm64" arch="aarch64"/>
+    </packages>
+    <packages type="image" profiles="Tumbleweed.RaspberryPi5">
+        <!-- For WiFi: -->
+        <package name="kernel-firmware-brcm"/>
     </packages>
     <packages type="bootstrap">
         <package name="ca-certificates"/>


### PR DESCRIPTION
Fixes #213.

- Update of profiles to Leap 16.0 where applicable, since 15.6 is now EOL [phillxnet edit "incomplete adaptation"]
- Introduce Raspberry Pi 5 (rpi5) profile
- Update installation package requirements for host as well as rockstor image definition.
- Update Readme referencing above changes

- I successfully built a Tumbleweed x86_64 image and installed & configured it as well as ran all tests successfully.
- I successfully built a Tumbleweed rpi5 image and installed & configured it as well as ran all tests successfully.