### PR TITLE
Fix Leap 16 profiles re openSUSE-release to Leap-release #217

### DIFF
--- a/config.sh
+++ b/config.sh
@@ -97,10 +97,10 @@ fi
 #=====================================
 # Edit the base distro openSUSE license files in accordance with the following:
 # https://en.opensuse.org/Archive:Making_an_openSUSE_based_distribution
-# Files to edit /usr/share/licenses/openSUSE-release/*.txt
+# Files to edit /usr/share/licenses/product/base/*.txt
 #-------------------------------------
 shopt -s nullglob
-for license_file in /usr/share/licenses/openSUSE-release/*.txt
+for license_file in /usr/share/licenses/product/base/*.txt
 do
     sed -i 's/openSUSE®/Rockstor "Built on openSUSE"/g' "${license_file}"
     sed -i 's/The openSUSE Project/The Rockstor Project/g' "${license_file}"

--- a/rockstor.kiwi
+++ b/rockstor.kiwi
@@ -367,12 +367,17 @@
         <package name="cracklib-dict-full"/>
         <package name="filesystem"/>
         <package name="gawk"/>
-        <package name="glibc-locale"/>  <!-- possbily glibc-locale-base -->
+        <package name="glibc-locale"/>  <!-- possibly glibc-locale-base -->
         <package name="grep"/>
         <package name="gzip"/>
         <package name="diffutils"/>
-        <package name="openSUSE-release"/>  <!-- /etc/os-release etc -->
         <package name="udev"/>
         <package name="xz"/>
+    </packages>
+    <packages type="bootstrap" profiles="Slowroll.x86_64,Tumbleweed.x86_64,Tumbleweed.RaspberryPi4,Tumbleweed.RaspberryPi5,Tumbleweed.ARM64EFI">
+        <package name="openSUSE-release"/>  <!-- /etc/os-release etc -->
+    </packages>
+    <packages type="bootstrap" profiles="Leap16.0.x86_64,Leap16.0.RaspberryPi4,Leap16.0.ARM64EFI">
+        <package name="Leap-release"/>  <!-- /etc/os-release etc -->
     </packages>
 </image>


### PR DESCRIPTION
Add Profile aware extensions to `<packages type="bootstrap">` to conditionally install "Leap-release" on Leap profiles only. All other profiles should install "openSUSE-release".

Modify License machine edits in config.sh to use common paths to both packages.

Fixes #217 

---

Upstream reference: https://osinside.github.io/kiwi/image_description/elements.html#profiles